### PR TITLE
Clarify Energy Resistance

### DIFF
--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -492,8 +492,8 @@
   effect: |
     Choose from the following energy types: fire, cold, lightning, acid, (or another at the GM’s discretion).  When you are attacked with that energy type, you gain resistance to the attack as follows:
       <ul>
-      <li><strong>Tier 1</strong> - Your defense scores are increased by 5 against the chosen attack type. </li>
-      <li><strong>Tier 2</strong> - Your defense scores are increased by 5 against the chosen attack type.</li>
+      <li><strong>Tier 1</strong> - Your defense scores are increased by 5 against the chosen attack type.</li>
+      <li><strong>Tier 2</strong> - Your defense scores are increased by 5 again against the chosen attack type.</li>
       <li><strong>Tier 3</strong> - You are immune to damage from the chosen attack type.</li>
       </ul>
 - !


### PR DESCRIPTION
As stated in issue #64, clarifying Energy Resistance. Didn't change Tier 2 to say '10' because that could be interpreted to add 10, for a total of 15.