### PR TITLE
Heal boon, duplicate dice explosion reminder

### DIFF
--- a/boons/boons.yml
+++ b/boons/boons.yml
@@ -231,7 +231,7 @@
   description: |
     Healing is magical energy overflowing from a creative life force which heals wounds and mends broken bones.
   effect: |
-    Roll dice according to the boon power level below. These dice explode as normal. The target is healed a number of hit points equal to the total roll. Like all dice rolls, these dice explode.
+    Roll dice according to the boon power level below. These dice explode as normal. The target is healed a number of hit points equal to the total roll.
     <strong>Special:</strong> This boon does not heal lethal damage.
     <ul>
     <li><strong>Power Level 1</strong> - Heal 1d4 </li>


### PR DESCRIPTION
Heal boon had two reminders that the dice explode.