### PR TITLE
Added advantage 1 when dual-wielding

### DIFF
--- a/core/src/04-wealth-equipment/01-chapter-four.md
+++ b/core/src/04-wealth-equipment/01-chapter-four.md
@@ -90,7 +90,7 @@ In addition, if you make a bane attack with the weapon, you get advantage 1 on t
 
 **Heavy** – The weapon is particularly heavy to carry. You may carry a maximum number of *heavy* items equal to your Might score plus one.
 
-**One-handed** – The weapon uses a single hand and allows the other hand to be used for carrying a shield, second weapon, or kept free for other actions.
+**One-handed** – The weapon uses a single hand and allows the other hand to be used for carrying a shield, second weapon, or kept free for other actions. Wielding a one-handed melee weapon in each hand grants advantage 1 to all attacks; attacks made with both hands are usually more deadly.
 
 **Precise** –  This weapon can be used to make attacks with the Agility attribute.
 

--- a/core/src/04-wealth-equipment/01-chapter-four.md
+++ b/core/src/04-wealth-equipment/01-chapter-four.md
@@ -111,6 +111,7 @@ In addition, if you make a bane attack with the weapon, you get advantage 1 on t
 
 | Weapon | Wealth Level | Properties | Banes |
 | :- | :- | :--- | :-- |
+| Unarmed Strike | 0 | Precise, Forceful, Swift 2 | - |
 | Dagger | 1 | One-handed, Precise, Swift 2, Range 25' | Persistent Damage |
 | Longsword | 2 | Versatile, Forceful, Precise | – |
 | Unarmed | - | One-handed, Forceful, Precise | – |

--- a/core/src/06-combat/01-chapter-six.md
+++ b/core/src/06-combat/01-chapter-six.md
@@ -446,13 +446,13 @@ You may also use your interrupt action in order to improvise a response to a sit
 
 Your hit points (HP) are an abstract measure of your character’s ability to ignore pain, avoid deadly blows, and maintain a presence on the battlefield in spite of wounds or exhaustion. Whenever you take damage, your hit points are reduced, and whenever you receive healing they are increased.
 
+### Finishing Blows
+
+When you suffer a damaging attack while unconscious, incapacitated, or otherwise unable to defend yourself, the attack counts as a **finishing blow** and may cause immediate death. Your defense against a finishing blow does not include your Fortitude or Agility attributes. Furthermore, if a finishing blow deals any damage, you must make a Fortitude roll with a Challenge Rating equal to 10 plus the damage dealt. If you fail this roll, you are dead.
+
 ### Reaching Zero Hit Points
 
 When you reach zero HP, you fall unconscious. Your hit points cannot be reduced below zero. While unconscious, you are helpless and any attack made against you counts as a finishing blow. Any healing that you receive to bring your hit points above zero also causes you to regain consciousness.
-
-### Finishing Blows
-
-When you suffer an attack while unconscious, incapacitated, or otherwise unable to defend yourself, you must make a Fortitude roll with a Challenge Rating equal to half the damage dealt. If you fail this roll, you are dead.
 
 ### Healing After Combat
 

--- a/core/src/06-combat/01-chapter-six.md
+++ b/core/src/06-combat/01-chapter-six.md
@@ -394,7 +394,7 @@ Only voluntary movement made on the moving character's turn trigger opportunity 
 
 Many boons have a default duration of *sustain persists*, which means that every time a character uses the **sustain** action, the boon remains in effect for 1 additional round. If you have a boon in effect and do not sustain it, the boon ends when your turn is over. Because sustaining a boon is a minor action, you can normally only sustain one boon at a time, and you cannot sustain a boon on a round in which you take a focus action.
 
-> ###### Sustaining Boon Examples
+> ##### Sustaining Boon Examples
 >
 > Ruby invokes the *flight* boon and takes to the skies. On her next turn, she wants to keep the *flight* active, so she uses a minor action to sustain it. An enemy then inflicts her with the *stunned* boon, limiting her to a single major, move, or minor action. When her turn comes up again, she uses a single move action to reach a safe landing spot. Because she is *stunned* she does not have a minor action to use to sustain the boon, so it ends when her turn is over.
 >

--- a/core/src/07-running-the-game/01-chapter-seven.md
+++ b/core/src/07-running-the-game/01-chapter-seven.md
@@ -58,7 +58,7 @@ Once you’ve got the starting pieces of your adventure sketched out, you can de
 
 In this sort of quest, the GM plans out a logical sequence of encounters and scenes that the party will work their way through. These events could be location-based (such as exploring a series of chambers in the Ziggurat of Kings), or they could be time-based (such as negotiating a peace treaty with the barbarian tribes). An adventure often contains a healthy mix of both location- and time-based scenes, as in the example adventure sketched out below.
 
-> #### The Kidnappings of Granny Maggot
+> #### Sample Sequential Adventure Outline: The Kidnappings of Granny Maggot
 > **Danger:** The children of Woodshold are disappearing one-by-one! Unbeknownst to the town, they are being collected by an evil hag named Granny Maggot for a dark ritual to cast the village into a deep malaise.
 >
 > **Motivation:** The first child to go missing is Wort, nephew to one of the PCs.
@@ -80,7 +80,7 @@ To develop a sequential adventure, you just have to plot out the most logical se
 
 A sandbox is so named because, to a certain extent, the players interact with the adventure in the same way that children explore a sandbox: at their own pace and for their own reasons. In this type of adventure, there is not typically a predictable order of events. Instead, the GM populates an area with plenty of opportunities for adventure and lets the story unfold naturally based on the players’ actions and the environment’s reactions. Just like a sequential adventure, a sandbox often contains both location- and time-based events. The outline below details a sandbox adventure revolving around a valley wilderness in which a barbarian tribe skirmishes with angelic visitors from another plane.
 
-> #### The Scattered Souls
+> #### Sample Sandbox Adventure Outline: The Scattered Souls
 >
 > **Danger:** A remote wilderness known as the Valley of Souls is home to a large collection of soul shards, magical crystals containing the lost souls of those killed in a cataclysmic war centuries ago. A team of angelic servants, called the Collectors, have been charged with retrieving these souls throughout the cosmos and returning them to their proper resting places among the outer planes. Unfortunately, two forces thwart their attempts within the Valley of Souls: a barbarian tribe whose sacred burial grounds contain the soul shards, and a demon named Vargax who seeks to devour the souls for his own.
 >
@@ -146,14 +146,19 @@ The big secret is an ideal way to start planning your campaign because it will p
 
 Once you have your secret (or secrets) sketched out, you can begin to divide the campaign into arcs, or extended storylines that develop the plot and reveal the secrets. You can plan these out from the beginning of the campaign to the end, or you can just start with the first few legs of the campaign - enough to get you started without bogging you down. The following outline imagines how a campaign revolving around one of the aforementioned secrets might develop.
 
-**Secret:** The wizardly patron, Magus, who advises the party throughout the campaign is actually an imprisoned red dragon manipulating them to win his freedom.
-
-**Campaign Arcs**
-
-**Part 1:** The party discovers Magus while exploring the Ruins of Excelsius.
-**Part 2:** The party assists Magus in recovering several items of power throughout the realm.
-**Part 3:** The party accidentally frees Magus. He reveals his true form and begins laying waste to the realm. The PCs work to gather allies to combat the army of giants the dragon is acquiring.
-**Part 4:** A final war erupts between Magus’s giants and the alliance of good. The party hunts Magus down to his volcanic lair.
+> #### Sample Campaign Outline
+>
+> **Secret:** The wizardly patron, Magus, who advises the party throughout the campaign is actually an imprisoned red dragon manipulating them to win his freedom.
+>
+> **Campaign Arcs**
+>
+> **Part 1:** The party discovers Magus while exploring the Ruins of Excelsius.
+>
+> **Part 2:** The party assists Magus in recovering several items of power throughout the realm.
+>
+> **Part 3:** The party accidentally frees Magus. He reveals his true form and begins laying waste to the realm. The PCs work to gather allies to combat the army of giants the dragon is acquiring.
+>
+> **Part 4:** A final war erupts between Magus’s giants and the alliance of good. The party hunts Magus down to his volcanic lair.
 
 Like most of the steps laid out in this guide to GMing, your campaign arcs should be planned relatively loosely to allow for players to shape the story by their own actions.
 

--- a/core/src/07-running-the-game/01-chapter-seven.md
+++ b/core/src/07-running-the-game/01-chapter-seven.md
@@ -58,20 +58,21 @@ Once you’ve got the starting pieces of your adventure sketched out, you can de
 
 In this sort of quest, the GM plans out a logical sequence of encounters and scenes that the party will work their way through. These events could be location-based (such as exploring a series of chambers in the Ziggurat of Kings), or they could be time-based (such as negotiating a peace treaty with the barbarian tribes). An adventure often contains a healthy mix of both location- and time-based scenes, as in the example adventure sketched out below.
 
-#### The Kidnappings of Granny Maggot
-**Danger:** The children of Woodshold are disappearing one-by-one! Unbeknownst to the town, they are being collected by an evil hag named Granny Maggot for a dark ritual to cast the village into a deep malaise.
-**Motivation:** The first child to go missing is Wort, nephew to one of the PCs.
-
-**Events**
-
-1. *Hunters hanging around the tavern complain that Hunter’s Hill has gone completely barren of wildlife (as a result of Granny’s malicious but unknown presence).*
-
-1. *A hunting party goes missing while exploring Hunter's Hill.
+> #### The Kidnappings of Granny Maggot
+> **Danger:** The children of Woodshold are disappearing one-by-one! Unbeknownst to the town, they are being collected by an evil hag named Granny Maggot for a dark ritual to cast the village into a deep malaise.
+>
+> **Motivation:** The first child to go missing is Wort, nephew to one of the PCs.
+>
+> **Events**
+>
+> 1. *Hunters hanging around the tavern complain that Hunter’s Hill has gone completely barren of wildlife (as a result of Granny’s malicious but unknown presence).*
+>
+> 1. *A hunting party goes missing while exploring Hunter's Hill.
 Granny's lifeless scarecrows appear east of town after sunrise. The distraction caused to the town is the perfect opportunity for her to kidnap her first victim.*
-
-1. *The party investigates the scene of the kidnapping, learning that the kidnapper left virtually no physical trace. Consulting a loremaster or simply via their own knowledge, the party surmises that a hag is the culprit.*
-
-1. *Putting two and two together, the party investigates Hunter’s Hill and discovers Granny Maggot’s lair, carved out of a giant pumpkin in the deep of the wood. If they are successful in overcoming her minions and defeating the hag, the party may be able to free Wort.*
+>
+> 1. *The party investigates the scene of the kidnapping, learning that the kidnapper left virtually no physical trace. Consulting a loremaster or simply via their own knowledge, the party surmises that a hag is the culprit.*
+>
+> 1. *Putting two and two together, the party investigates Hunter’s Hill and discovers Granny Maggot’s lair, carved out of a giant pumpkin in the deep of the wood. If they are successful in overcoming her minions and defeating the hag, the party may be able to free Wort.*
 
 To develop a sequential adventure, you just have to plot out the most logical sequence of events that will occur based on the party’s actions. Start with a simple list like the one above. It’s best not to get too specific, lest you fall into the trap of forcing the PCs into a single direction. Instead, leave your plan loose enough to redirect it according to how your players interact with the world. For example, what if the party never puts two and two together during their investigations in event 4 above? Maybe then a second child is kidnapped a few days later, but this time there is a witness who catches a glimpse of the hag.
 
@@ -79,41 +80,39 @@ To develop a sequential adventure, you just have to plot out the most logical se
 
 A sandbox is so named because, to a certain extent, the players interact with the adventure in the same way that children explore a sandbox: at their own pace and for their own reasons. In this type of adventure, there is not typically a predictable order of events. Instead, the GM populates an area with plenty of opportunities for adventure and lets the story unfold naturally based on the players’ actions and the environment’s reactions. Just like a sequential adventure, a sandbox often contains both location- and time-based events. The outline below details a sandbox adventure revolving around a valley wilderness in which a barbarian tribe skirmishes with angelic visitors from another plane.
 
-#### The Scattered Souls
-
-**Danger:** A remote wilderness known as the Valley of Souls is home to a large collection of soul shards, magical crystals containing the lost souls of those killed in a cataclysmic war centuries ago. A team of angelic servants, called the Collectors, have been charged with retrieving these souls throughout the cosmos and returning them to their proper resting places among the outer planes. Unfortunately, two forces thwart their attempts within the Valley of Souls: a barbarian tribe whose sacred burial grounds contain the soul shards, and a demon named Vargax who seeks to devour the souls for his own.
-
-**Motivation:** The party happens upon the valley during their travels and are thrown into the battle when both the Collectors and the barbarians mistake the PCs for members of the opposition.
-
-**Locations**
-
-- **The barbarian camps**
-
-- **The barbarian burial grounds**
-
-- **The Caverns of Chaos**
-
-- **The Collector camp**
-
-**Vargax Events**
-
-1. *Vargax sends an emissary to the barbarians.
-Vargax wins over the tribe’s trust by delivering the head of a Collector.*
-
-1. *Vargax converts the barbarian shamans to worship him.
-The tribe as a whole begins transformation under demonic influence.*
-
-1. *Vargax displaces the barbarian chief and assumes control of the tribe.*
-
-**Collector Events**
-
-1. *The Collectors increase reconnaissance missions surrounding the barbarian camps.*
-
-1. *With their newfound intelligence, the Collectors kidnap the son of the barbarian chief, demanding access to the burial grounds as ransom.*
-
-1. *Civil war erupts within the tribe, with half of the barbarians supporting the chief’s decision to provide the ransom, and half opposing.*
-
-1. *Infighting reduces the tribe’s strength significantly, allowing the Collectors to force their way into the burial grounds.*
+> #### The Scattered Souls
+>
+> **Danger:** A remote wilderness known as the Valley of Souls is home to a large collection of soul shards, magical crystals containing the lost souls of those killed in a cataclysmic war centuries ago. A team of angelic servants, called the Collectors, have been charged with retrieving these souls throughout the cosmos and returning them to their proper resting places among the outer planes. Unfortunately, two forces thwart their attempts within the Valley of Souls: a barbarian tribe whose sacred burial grounds contain the soul shards, and a demon named Vargax who seeks to devour the souls for his own.
+>
+> **Motivation:** The party happens upon the valley during their travels and are thrown into the battle when both the Collectors and the barbarians mistake the PCs for members of the opposition.
+> 
+> **Locations**
+>
+> - **The barbarian camps**
+>
+> - **The barbarian burial grounds**
+>
+> - **The Caverns of Chaos**
+>
+> - **The Collector camp**
+>
+> **Vargax Events**
+>
+> 1. *Vargax sends an emissary to the barbarians. Vargax wins over the tribe’s trust by delivering the head of a Collector.*
+>
+> 1. *Vargax converts the barbarian shamans to worship him. The tribe as a whole begins transformation under demonic influence.*
+>
+> 1. *Vargax displaces the barbarian chief and assumes control of the tribe.*
+>
+> **Collector Events**
+>
+> 1. *The Collectors increase reconnaissance missions surrounding the barbarian camps.*
+>
+> 1. *With their newfound intelligence, the Collectors kidnap the son of the barbarian chief, demanding access to the burial grounds as ransom.*
+>
+> 1. *Civil war erupts within the tribe, with half of the barbarians supporting the chief’s decision to provide the ransom, and half opposing.*
+>
+> 1. *Infighting reduces the tribe’s strength significantly, allowing the Collectors to force their way into the burial grounds.*
 
 Developing a sandbox adventure is similar to developing a sequential one, in that you plan out the logical sequence of events. In this case, however, because the PCs have so much room for decision making, the outline differs slightly. The GM plans out all of the relevant locations to the adventure, perhaps mapping and populating them if necessary. Additionally, the GM will make a list for the key actors in the adventure. The list provides a series of events that will occur if the party does nothing to intervene.
 
@@ -294,9 +293,9 @@ But sometimes it can add to the story to have an ally contribute in a way that t
 
 The above example will likely be an intriguing scene enjoyed by all, because the ally NPC can’t prevail without the help of the players.
 
-*Allies can be used to grant knowledge.* In addition to providing players with new power, allies can also be the purveyors of information. A savvy merchant knows how to gain leverage on the members of the trader’s guild; a pitiful sanitation clerk turned wererat possesses the only known map of the city sewers; a sage who acts as patron to the party has discovered the location of the Ring of Worlds. By using allies to inform the players of secret or hidden knowledge, you put the power of what to do with that information in the PCs’ hands.
+**Allies can be used to grant knowledge.** In addition to providing players with new power, allies can also be the purveyors of information. A savvy merchant knows how to gain leverage on the members of the trader’s guild; a pitiful sanitation clerk turned wererat possesses the only known map of the city sewers; a sage who acts as patron to the party has discovered the location of the Ring of Worlds. By using allies to inform the players of secret or hidden knowledge, you put the power of what to do with that information in the PCs’ hands.
 
-*Allies should be imperfect.* The best allies are the ones who are flawed just like the PCs. They have physical weaknesses that can be taken advantage of, moral faults that can be exploited, or needs that they can’t fulfill on their own. If the allies are so powerful that no mortal can stop them and they want for nothing, the players are likely to wonder why the NPC is giving them the time of day in the first place.and, by finding ways to demonstrate your NPCs’ imperfections, you'll further immerse your players in the fantasy.
+**Allies should be imperfect.** The best allies are the ones who are flawed just like the PCs. They have physical weaknesses that can be taken advantage of, moral faults that can be exploited, or needs that they can’t fulfill on their own. If the allies are so powerful that no mortal can stop them and they want for nothing, the players are likely to wonder why the NPC is giving them the time of day in the first place.and, by finding ways to demonstrate your NPCs’ imperfections, you'll further immerse your players in the fantasy.
 
 ### Monsters and NPC Statistics
 
@@ -391,11 +390,11 @@ Once you have the basic statistics recorded, choose a few of the following feats
 - **Superior Concentration (tier 1 - 3, your choice):** Without this feat, only a single boon can be persisted with the Sustain minor action. Purchasing this feat allows you to sustain one additional boon simultaneously without losing focus on the others you are already focusing on.
 Special: This feat can be purchased multiple times (up to a maximum of 3), each time it is purchased you can maintain one more boon with the Sustain minor action.
 
-#### Example Simple Monster Build: Swamp Snakes
-
-Returning to the example at the beginning of this section, let’s build our venomous swamp snakes imagining that the party is made up of 3rd level characters. We decide that the snakes aren’t particularly tough to kill, so referencing the Simple Build Table, we’ll give them the low end of the suggested range and settle on 14 hit points each. When it comes to defenses, snakes are fast, mildly sturdy, and weak willed. So, we’ll go with the high range for Evasion: 18, the middle range for Toughness: 15, and the low range for Resolve: 12. We’ll only assign one primary attribute, giving the snakes an Agility of 5, and we’ll assign Perception, Fortitude, and Deception as secondary attributes with a score of 4.
-
-When it comes to feats, we decide to highlight the danger of the venom by choosing Multi Bane Specialist and Bane Focus to allow the snakes to inflict both the stunned and persistent damage banes whenever they land an attack that deals at least 5 damage.
+> #### Example Simple Monster Build: Swamp Snakes
+> 
+> Returning to the example at the beginning of this section, let’s build our venomous swamp snakes imagining that the party is made up of 3rd level characters. We decide that the snakes aren’t particularly tough to kill, so referencing the Simple Build Table, we’ll give them the low end of the suggested range and settle on 14 hit points each. When it comes to defenses, snakes are fast, mildly sturdy, and weak willed. So, we’ll go with the high range for Evasion: 18, the middle range for Toughness: 15, and the low range for Resolve: 12. We’ll only assign one primary attribute, giving the snakes an Agility of 5, and we’ll assign Perception, Fortitude, and Deception as secondary attributes with a score of 4.
+>
+> When it comes to feats, we decide to highlight the danger of the venom by choosing Multi Bane Specialist and Bane Focus to allow the snakes to inflict both the stunned and persistent damage banes whenever they land an attack that deals at least 5 damage.
 
 #### Boss Monsters and NPCs
 

--- a/core/src/07-running-the-game/01-chapter-seven.md
+++ b/core/src/07-running-the-game/01-chapter-seven.md
@@ -324,7 +324,7 @@ The simple build option is useful when you need to come up with statistics on th
 | - |
 | |
 
-| Party Level | Hit Points | Defenses | Primary Attributes | Secondary Attributes |
+| NPC Level | Hit Points | Defenses | Primary Attributes | Secondary Attributes |
 | :-: | :-: | :-: | :-: | :-: |
 | 1 | 10 - 22 | 10 - 18 | 4 | 3 |
 | 2 | 12 - 24 | 11 - 18 | 5 | 3 |
@@ -338,11 +338,11 @@ The simple build option is useful when you need to come up with statistics on th
 | 10 | 28 - 40 | 19 - 25 | 9 | 7 |
 
 
-Based on the party’s level, use the NPC Simple Build Table to determine the monster’s most relevant statistics. For the hit point and defense columns, choose values within the given ranges based on the strengths and weaknesses of the monster you are building. Choose 1 to 3 primary attributes that will form the main basis of the monster’s attacks and actions, and then choose as many secondary attributes as you need in order to define the monster’s other capabilities.
+Use the NPC Simple Build Table to determine the monster’s most relevant statistics. For the hit point and defense columns, choose values within the given ranges based on the strengths and weaknesses of the monster you are building. Choose 1 to 3 primary attributes that will form the main basis of the monster’s attacks and actions, and then choose as many secondary attributes as you need in order to define the monster’s other capabilities.
 
 Once you have the basic statistics recorded, choose a few of the following feats to provide your monster with special attacks and abilities:
 
-- **Attack Specialization (tier equal to party level, max 9):** With one attack type, gain advantage 1 per tier.
+- **Attack Specialization (tier equal to NPC level, max 9):** With one attack type, gain advantage 1 per tier.
 
 - **Bane Focus:** Pick a bane. Whenever you inflict at least five damage with an attack, you may automatically inflict that bane.
 
@@ -366,7 +366,7 @@ Once you have the basic statistics recorded, choose a few of the following feats
 
 - **Evasive Footwork:** When you move from a square adjacent to an enemy to another square not adjacent to that enemy, the enemy does not get the usual opportunity attack.
 
-- **Lethal Strike (tier equal to party level, max 9):** Lethal strikes can be delivered to do lethal damage (that does not heal normally) under specific circumstances. There are two different ways to deliver a lethal strike:
+- **Lethal Strike (tier equal to NPC level, max 9):** Lethal strikes can be delivered to do lethal damage (that does not heal normally) under specific circumstances. There are two different ways to deliver a lethal strike:
     1. Catch an enemy by surprise, either due to not seeing you via Agility or through disguise / subterfuge via Deception.
     2. If an enemy is adjacent to an ally wielding a melee weapon, then you can make a lethal strike against that enemy.
 
@@ -382,22 +382,22 @@ Once you have the basic statistics recorded, choose a few of the following feats
     - **Tier 8** - Advantage 8, Max lethal damage 25
     - **Tier 9** - Advantage 9, Max lethal damage 30
 
-- **Multi Attack Specialist (tier equals party level, max 6):** When you make an attack, you can choose to incur disadvantage 3, in exchange for an additional attack. You can use this ability to gain more than one additional attack. You can move between each of these attacks or otherwise divide them. You must decide before your first attack whether or not to use this feat. The disadvantage applies to all attacks for this turn. For each tier of this feat you offset the disadvantage penalty by 1.
+- **Multi Attack Specialist (tier equals NPC level, max 6):** When you make an attack, you can choose to incur disadvantage 3, in exchange for an additional attack. You can use this ability to gain more than one additional attack. You can move between each of these attacks or otherwise divide them. You must decide before your first attack whether or not to use this feat. The disadvantage applies to all attacks for this turn. For each tier of this feat you offset the disadvantage penalty by 1.
 
-- **Multi Target Attack Specialist (tier equals party level, max 5):** Choose either area, projectile, or melee when you take this feat. For each tier, you offset the disadvantage penalty associated with by 1. So, when you would normally get disadvantage 2, you instead get disadvantage 1 and so on.
+- **Multi Target Attack Specialist (tier equals NPC level, max 5):** Choose either area, projectile, or melee when you take this feat. For each tier, you offset the disadvantage penalty associated with by 1. So, when you would normally get disadvantage 2, you instead get disadvantage 1 and so on.
 
 - **Multi Bane Specialist:** Choose two banes that you are able to inflict. You are able to make attacks that inflict your targets with both banes at once. Your attribute score must be equal to or greater than the power level of both banes combined. If the two banes use different key attributes, provided your key attributes for both banes is sufficient, you use the higher of the two attributes for both the attack and determining if you are powerful enough to combine them.
 
 - **Potent Bane:** Choose a bane. When you invoke the chosen bane on a target, Resist rolls to shake off the bane have Disadvantage (the target rolls 2d20 and keeps the lowest, contrary to normal action rolls).
 
-- **Resilient:** Any time you make a Resist roll, you have Advantage on the d20 roll (roll 2 d20 and keep the higher, contrary to normal action rolls).
+- **Resilient:** Any time you make a Resist roll, you have advantage on the d20 roll (roll 2 d20 and keep the higher, contrary to normal action rolls).
 
 - **Superior Concentration (tier 1 - 3, your choice):** Without this feat, only a single boon can be persisted with the Sustain minor action. Purchasing this feat allows you to sustain one additional boon simultaneously without losing focus on the others you are already focusing on.
 Special: This feat can be purchased multiple times (up to a maximum of 3), each time it is purchased you can maintain one more boon with the Sustain minor action.
 
 > #### Example Simple Monster Build: Swamp Snakes
 > 
-> Returning to the example at the beginning of this section, let’s build our venomous swamp snakes imagining that the party is made up of 3rd level characters. We decide that the snakes aren’t particularly tough to kill, so referencing the Simple Build Table, we’ll give them the low end of the suggested range and settle on 14 hit points each. When it comes to defenses, snakes are fast, mildly sturdy, and weak willed. So, we’ll go with the high range for Evasion: 18, the middle range for Toughness: 15, and the low range for Resolve: 12. We’ll only assign one primary attribute, giving the snakes an Agility of 5, and we’ll assign Perception, Fortitude, and Deception as secondary attributes with a score of 4.
+> Returning to the example at the beginning of this section, let’s build our venomous swamp snakes imagining that the party is made up of 3rd level characters, and thus we choose to make the Swamp Snakes using the row for level 3 Monsters. We decide that the snakes aren’t particularly tough to kill, so referencing the Simple Build Table, we’ll give them the low end of the suggested range and settle on 14 hit points each. When it comes to defenses, snakes are fast, mildly sturdy, and weak willed. So, we’ll go with the high range for Evasion: 18, the middle range for Toughness: 15, and the low range for Resolve: 12. We’ll only assign one primary attribute, giving the snakes an Agility of 5, and we’ll assign Perception, Fortitude, and Deception as secondary attributes with a score of 4.
 >
 > When it comes to feats, we decide to highlight the danger of the venom by choosing Multi Bane Specialist and Bane Focus to allow the snakes to inflict both the stunned and persistent damage banes whenever they land an attack that deals at least 5 damage.
 
@@ -413,7 +413,7 @@ When you decide that one of your monsters or NPCs merits boss status, use the Bo
 | - |
 | |
 
-| Party Level | Hit Points | Defenses | Primary Attributes | Secondary Attributes | Boss Actions |
+| Boss Level | Hit Points | Defenses | Primary Attributes | Secondary Attributes | Boss Actions |
 | :-: | :-: | :-: | :-: | :-: | :-: |
 | 1 | 40 | 13 - 16 | 6 | 4 | 1 |
 | 2 | 50 | 14 - 17 | 6 | 4 | 1 |


### PR DESCRIPTION
Currently you need feats to get anything out of dual-wielding 2 one-handed weapons. 
When choosing to wield 2 weapons, you are choosing to not carry a shield. So there should be some kind of inherent benefit to it. Attacking with 2 one-handed weapons should not be the same as attacking with a single one-handed weapon while wearing a shield in the other hand. 
And attacking with 2 one-handed weapons is comparable to attacking with a single two-handed weapon. In the sense that you use both hands for attacking. And don't have a free hand for a shield. 

Another thing: If you take the Multi-Attack Specialist feat to simulate attacking with both weapons, you would actually have an easier time multi-attacking with a single two-handed weapon, because of the extra advantage 1 you get, just for it being a two-handed weapon. That seems wrong. Multi-attacking should not be easier with a two-handed weapon than when dual-wielding 2 one-handed weapons.