### PR TITLE
Banes min-prereq now 1.

### DIFF
--- a/banes/banes.yml
+++ b/banes/banes.yml
@@ -279,7 +279,7 @@
   - Supernatural
   - Physical
   power:
-  - 0
+  - 1
   attackAttributes:
   - Agility
   - Alteration


### PR DESCRIPTION
Surprised is still 0, since it's N/A and dictated by the DM. Immobile is updated and a run through Boons/Banes reveals it's a min pre-reqof 1 across the board aside from Surprised now.