### PR TITLE
Fix prerequisites for Fleet of Foot feat

### DIFF
--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -879,12 +879,12 @@
       - Agility: 4
       - Fortitiude: 4
       - Movement: 2
-  -tier2:
+    tier2:
       Attribute:
       - Agility: 5
       - Fortitiude: 5
       - Movement: 4
-  -tier3:
+    tier3:
       Attribute:
       - Agility: 7
       - Fortitiude: 7


### PR DESCRIPTION
Fix incorrect yaml syntax that would prevent the prerequisites to be properly parsed.