### PR TITLE
Fix incorrect tier levels for Inspiring Champion feat

### DIFF
--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -1119,10 +1119,10 @@
     tier1:
       Attribute:
       - Presence: 4
-    tier1:
+    tier2:
       Attribute:
       - Presence: 5
-    tier1:
+    tier3:
       Attribute:
       - Presence: 6
   tags:


### PR DESCRIPTION
Fix repeating tier level. Now tier levels are ascending.