### PR TITLE
Add tier info to Knowledge feat name to maintain consistency

### DIFF
--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -1141,7 +1141,7 @@
     <li><strong>Tier 3</strong> - All allies who can see the attack heal 2d4 HP.</li>
     </ul>
 - !
-  name: Knowledge
+  name: Knowledge (I - III)
   prerequisites:
     tier1:
       Other:


### PR DESCRIPTION
Renamed `Knowledge` to `Knowledge (I - III)` to maintain the consistency for feat with multiple tiers to have the tier range expressed in the name (e.g. `Battlefield Sentinel (I - V)`).