### PR TITLE
Create dynamic_defense

### DIFF
--- a/core/src/06-combat/dynamic_defense
+++ b/core/src/06-combat/dynamic_defense
@@ -1,0 +1,3 @@
+It would be nice if rolling Toughness, Evasion and Resolve instead of having fixed values for all those three could at least be an 
+option if you are actively resisting attacks. It would make combat more dynamic because as of yet just attacks can explode and not 
+defensive actions.


### PR DESCRIPTION
It would be nice if rolling Toughness, Evasion and Resolve instead of having fixed values for all those three could at least be an option if you are actively resisting attacks. It would make combat more dynamic because as of yet just attacks can explode and not defensive actions.