### PR TITLE
Suggestion: Supernatural Attribute Zero notice

### DIFF
--- a/core/src/01-character-creation/01-chapter-one.md
+++ b/core/src/01-character-creation/01-chapter-one.md
@@ -80,6 +80,10 @@ The Attributes at a Glance tables provide a quick overview of some of the common
 
 In *Open Legend*, you get to define your character’s strengths and weaknesses by choosing the attributes that fit your character concept. Described below are several methods by which you can assign your attributes.
 
+> ### Supernatural Attribute with Score Zero
+>
+> A score of zero for a supernatural attribute means that you have yet to manifest that power, therefore you can't use it for any type of action roll.
+
 ### Quick Build
 
   If you are new to roleplaying games, or are just looking to get your character built quickly, choose one of the attribute sets listed in the Attribute Quick Builds table. Assign the scores listed to the attributes that define the type of character you want to play. The rest of your attributes begin with a score of zero.
@@ -773,4 +777,3 @@ See [*Feats*](http://www.openlegendrpg.com/feats) to view the complete list of f
 ### New Hit Points
 
 In Open Legend, attributes are the means by which your hit points increase. If you want your character to be able to take more hits, increase either your Fortitude, Presence, or Will attribute. As outlined in the default hit point formula, you’ll gain 2 hit points each time you raise any of those attributes by one.
-

--- a/core/src/02-actions-attributes/01-chapter-two.md
+++ b/core/src/02-actions-attributes/01-chapter-two.md
@@ -8,6 +8,10 @@ interpret the results.
 *Open Legend* is about creating great stories full of epic moments of heroism, and you roll dice to determine the outcome of those moments. In short, you only need to make action rolls when the outcome of the intended action plays a significant role in the story. In combat, for
 example, you’ll be making plenty of action rolls to clash blades, sling spells, and leap over treacherous chasms. But you don’t need to roll a Persuasion check every time you go to buy something from the bazaar, and you don’t need to roll Logic to remember where you left the key to your room at the inn.
 
+> ### Supernatural Attribute with Score Zero
+>
+> A score of zero for a supernatural attribute means that you have yet to manifest that power, therefore you can't use it for any type of action roll.
+
 ## Every Roll Matters
 
 Another important point in *Open Legend* is that every action roll should drive the story in a new direction, for better or worse. A failed roll should not let the story stagnate, nor should a failure be easily negated by a successful roll from another character.
@@ -160,7 +164,7 @@ Disadvantage works in a similar manner. When you have disadvantage, you still ro
 
 ### Advantage and Disadvantage Are Only Applied BEFORE Explosions
 
-Advantage and Disadvantage only apply to your initial pool of dice for an action roll. They do not apply to subsequent rolls granted by exploding dice. 
+Advantage and Disadvantage only apply to your initial pool of dice for an action roll. They do not apply to subsequent rolls granted by exploding dice.
 
 > #### Example of Advantage with Exploding Dice
 > Imagine you have attribute score 4 and are rolling with advantage 2, you would roll 1d20 + 3d8 and keep the single highest of the d8s before rolling any exploding dice. Imagine your d20 rolls a 10 and your d8s land on 8, 8, and 3. You would then keep one of the 8s and discard the other two dice. Because the 8 rolled max, you may roll it again and add the result to your total. Imagine that lands on a 5. Your total score is 23 (10 + 8 + 5).
@@ -216,7 +220,7 @@ An additional layer of depth to action resolution comes in the form of legend po
 Characters begin play with zero legend points, and the maximum they may acquire is 10. The GM may reward a PC with a legend point when they use one of their flaws to their own disadvantage or for particularly strong roleplaying (see Chapter 1: Character Creation).
 
 > ### Example of Earning a Legend Point
-> 
+>
 > Zaax has the *hot tempered* flaw, causing him to easily lose control of his anger. In the middle of the party’s tense negotiations with the Imperial Guard, Zaax loses his patience with the high commander and shoots one of the guardsmen. This is a clear example of Zaax roleplaying his flaw despite negative consequences, so the GM awards him with a legend point.
 
 The GM may also feel free to establish other rules for awarding legend points. For example, some GMs like to allow each player to award another PC one legend point each session. Other tables might have a vote for MVP or best roleplayer at the end of each session, with the winner gaining a legend point.

--- a/core/src/06-combat/01-chapter-six.md
+++ b/core/src/06-combat/01-chapter-six.md
@@ -48,7 +48,7 @@ If any characters are surprised, keep two initiative orders: one for surprised c
 > The final initiative order is as follows:
 >
 >> **Non-surprised Combatants**
->> 
+>>
 >> Jalani 25 (On her first turn, she must draw her Las Pistol)
 >>
 >> Griblicks 11
@@ -89,6 +89,10 @@ around and sweeps Vera to the floor.
 ## Using Attributes to Inflict Damage
 
 Combat in *Open Legend* is a swirl of action rolls as blades clash, traps spring, lightning forks, and arrows fly. However, because of the free-form nature of storytelling in *Open Legend*, you may not always know what attributes can be used to make attacks.
+
+> ### Supernatural Attribute with Score Zero
+>
+> A score of zero for a supernatural attribute means that you have yet to manifest that power, therefore you can't use it for inflicting damage.
 
 ### Always
 
@@ -262,7 +266,7 @@ The [*bane descriptions*](http://www.openlegendrpg.com/banes) also indicate whic
 > Setting Sun is heavily wounded and needs a chance to escape from the samurai who is mercilessly pressing the attack. With a well timed snake strike, the monk attempts to blind the armored warrior. Setting Sun is making a melee attack targeting a single foe, so he makes an action roll using his Agility of 5 versus the samurai's Evasion of 18. The monk rolls 1d20 + 2d6 and scores a 20, so his foe is inflicted with the *blinded* bane.
 >
 > * * * * *
-> 
+>
 > Zarthakis, the great wyrm, is surrounded by a party of 4 adventurers. He unfurls the full fury of his wings and bellows a mighty roar, instilling terror in his foes as he attempts to inflict the Demoralized Bane using his Presence attribute. The dragon's Presence is 8, giving him a range of 75', quite enough to target all of the heroes. Because Zarthakis is multi-targeting 4 foes, he has disadvantage 4 on his action roll. Normally, he would roll 1d20 + 3d8, but because he has disadvantage, the wyrm rolls 1d20 + 7d8 (keeping the lowest 3 d8s). His total score is 22, which he compares to each target's Resolve defense score separately. The heroes have Resolve scores of 14, 17, 22, and 25, so the dragon manages to inflict the bane on three of the four.
 
 #### Invoke a Boon
@@ -276,7 +280,7 @@ Boon invocations follow the same rules for determining range and number of targe
 
 ##### 2. Roll to Invoke
 
-Make an action roll using the appropriate attribute, as determined by the [*boon descriptions*](http://www.openlegendrpg.com/boons). 
+Make an action roll using the appropriate attribute, as determined by the [*boon descriptions*](http://www.openlegendrpg.com/boons).
 
 ##### 3. Determine Power Level
 
@@ -305,7 +309,7 @@ Some boons only possess a single power level, while others can be invoked at mul
 > Jade attempts to activate her reality distorter in order to make herself and an ally vanish with the *invisible* boon. Jade's Alteration attribute is 6, but she suffers disadvantage 2 due to multi-targeting. She rolls 1d20 + 4d8 (keeping the lowest 2 d8s) and gets a 20. *Invisible* is Power Level 6, so Jade falls short of the Challenge Rating of 22. The boon fails to take effect.
 >
 > * * * * *
-> 
+>
 > Stitch is attempting to close an ally's wounds by invoking the *Heal* boon. His Learning attribute is 5, so he rolls 1d20 + 2d6 and gets a total of 24. According to the Boon Challenge Rating table, Stitch rolled high enough to invoke the boon at power level 7. However, because his Learning attribute is 5, he can only invoke *heal* at power level 5, allowing him to heal his ally 2d6 hit points according to the boon description.
 
 #### Assist an Ally
@@ -374,11 +378,11 @@ Only voluntary movement made on the moving character's turn trigger opportunity 
 > Tommy has no choice but to flee from the three orcs that have closed upon him. He moves as far as he can to get away from them. However, because he moved from a space adjacent to them into a space not adjacent to them, all three orcs get to make an opportunity attack.
 >
 > * * * * *
-> 
+>
 > Vera is toe-to-toe with two snotlings who flee in terror as she enters a berserker rage. Both snotlings trigger an opportunity attack. However, because she is limited to one opportunity attack per round, Vera can only attack one of them.
 >
 > * * * * *
-> 
+>
 > Sergeant Rage is wielding a shotgun. A ratman dashes up to him, attacks with a dagger, and then dashes away. Because Sarge doesn't have a melee weapon equipped, he does not get an opportunity attack against the ratman.
 
 #### Sustaining Boons
@@ -426,7 +430,7 @@ As part of your defend action, you may also move up to half of your speed at any
 > Vera is nearing death when the River Troll lunges at her. The troll rolls a 23 against Vera's Toughness of 17, so she uses a defend action to catch the troll's arms before he can rend her to death. Vera makes a Might roll and gets a 20, so her roll replaces her Toughness, causing her to suffer 3 points of damage instead of 6. Because defend is an interrupt action, when Vera's turn in the initiative comes, she does not get a major action.
 >
 > * * * * *
-> 
+>
 > A grenade lands at the feet of Spaz and Tomlinson. The grenade rolls a 25 against their Toughness scores of 12 and 18, potentially dealing 13 and 7 damage, respectively. Tomlinson uses the defend action to move half his speed (15 feet) away, opting to move Spaz with him, and then makes an Agility roll to shield his ally. Tomlinson is wielding a riot shield, so he gets advantage 1 on his Agility roll, which totals 26. Spaz takes no damage. However, since the defend action can only affect a single target, Tomlinson still takes 7 points of damage. Because defend is an interrupt action, when Tomlinson's turn in the initiative comes, he does not get a major action.
 
 #### Improvise


### PR DESCRIPTION
Hacked something toghether as suggestion for #146.
Added a note in chapter 1 when creating the character, in chapter 2 when explaining action roll and in chapter 6 when describing suitable attributes for attacks.
I've now noticed that my editor has also removed some trailing whitespaces, but I don't think this is an issue. 