### PR TITLE
Various fixes

### DIFF
--- a/core/src/01-character-creation/01-chapter-one.md
+++ b/core/src/01-character-creation/01-chapter-one.md
@@ -172,7 +172,8 @@ In the Archetype Attribute Builds table, several common fantasy archetypes are l
 | Perception 3 | Persuasion 3 | Learning 3  |
 | Will 1 | Learning 1 | Logic 1  |
 | Entropy 3 | Creation 2 | Will 2  |
-| Movement 3 | Influence 4 | Protection 5  |
+| Movement 3 | Influence 4 | Movement 3  |
+| | | Protection 5 |
 
 
 ### Record Attribute Dice

--- a/core/src/01-character-creation/01-chapter-one.md
+++ b/core/src/01-character-creation/01-chapter-one.md
@@ -159,7 +159,7 @@ In the Archetype Attribute Builds table, several common fantasy archetypes are l
 | Presence 3 | Persuasion 1 |  Perception 2 |
 | Persuasion 3 | Learning 1 |  Will 2 |
 | Perception 3 | Will 2 |  Alteration 4 |
-| | Protection 4 | |
+| | Protection 4 | Creation 3 |
 | | Creation 5 | Influence 4 |
 
 <br>

--- a/core/src/01-character-creation/01-chapter-one.md
+++ b/core/src/01-character-creation/01-chapter-one.md
@@ -293,7 +293,7 @@ start with the feat selections recommended below:
 | Assassin | Cleric | Druid |
 | :- | :- | :- |
 | Martial Focus (Dagger) | Boon Focus (Heal) | Boon Focus (Shapeshift) |
-| Lethal Strike 1 | Armor Specialization 1 (Scale Mail) | Master Shifter 1 |
+| Lethal Strike 1 | Armor Specialization 1 (Scale Mail) |  |
 
 <br>
 
@@ -784,4 +784,3 @@ See [*Feats*](http://www.openlegendrpg.com/feats) to view the complete list of f
 ### New Hit Points
 
 In Open Legend, attributes are the means by which your hit points increase. If you want your character to be able to take more hits, increase either your Fortitude, Presence, or Will attribute. As outlined in the default hit point formula, you’ll gain 2 hit points each time you raise any of those attributes by one.
-

--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -21,8 +21,8 @@
     </ul>
     Whenever your primary form gains new attribute points or levels up, your alternate form also gains points according to the above formulas.
     You may transform from one form to another as a focus action. Each form is treated as a completely different character for mechanical purposes - possessing different attributes, feats, perks, flaws, and other defining characteristics. Your alternate form does, however, retain the ability to transform back into your primary form.
-    In order to keep track of hit points, you should always record the total damage that your character has suffered. When transforming, your damage remains with you even if your maximum hit points change. For example, Dr. Jekyll has a max HP of 15 and Mr. Hyde has a max HP of 30. During combat, Mr. Hyde suffers 10 damage. When he later transforms back into Dr. Jekyll, the 10 damage remains and is subtracted from his new maximum, leaving the doctor with 5 out of 15 hit points. 
-        
+    In order to keep track of hit points, you should always record the total damage that your character has suffered. When transforming, your damage remains with you even if your maximum hit points change. For example, Dr. Jekyll has a max HP of 15 and Mr. Hyde has a max HP of 30. During combat, Mr. Hyde suffers 10 damage. When he later transforms back into Dr. Jekyll, the 10 damage remains and is subtracted from his new maximum, leaving the doctor with 5 out of 15 hit points.
+
   special: |
     When selecting feats for your alternate form, you may not select the <strong>Alternate Form</strong> feat.
     You may take this feat multiple times. Each time grants you access to an additional form.
@@ -969,7 +969,7 @@
   effect: |
     When you invoke the Phantasm bane, you may choose to create a hallucination within a target's mind instead of an illusion that is perceptible to everyone. You gain complete control over the target's senses (as granted by the Power Level of your bane), and are thus the hallucination is not restricted by size or area. Your hallucination may only target a single creature, and thus is not eligible for multi-targeting attacks.
 - !
-  name: Hallucination (Mass)
+  name: Hallucination - Mass
   prerequisites:
     tier1:
       Attribute:


### PR DESCRIPTION
**Changes:**
- Renamed `Hallucination (Mass)` to `Hallucination - Mass` as suggested in #167. Closes #132.
- Added missing attributes to Druid and Arcane Protector, each missing a score 3 (example characters from Google Drive were used as references)
- Removed obsolete reference to `Master Shifter` in the Druid feat table

**Regarding `Master Shifter` removal**
With the removal of `Master Shifter` the Druid has now 3 feat points to spend at level 1. 
I didn't insert a new feat because I'm not sure of what to do. 
We could either go for `Boon Focus II (Shapeshift)`, so that at level 2 the Druid can purchase `Boon Focus III (Shapeshift)` and achieve the same effect as `Master Shifter`, or we can purchase `Boon Focus I (Heal)`, to underline the healing capabilities of this class.