### PR TITLE
Update Disrupting Attack to 10 over defense rule

### DIFF
--- a/core/src/06-combat/01-chapter-six.md
+++ b/core/src/06-combat/01-chapter-six.md
@@ -407,7 +407,7 @@ Using a focus action involves spending all of your energy and attention on one t
 
 #### Disrupting Attack
 
-Make a damaging attack using the normal attack rules. If your attack deals 10 or more points of damage, then any boons being sustained by your target immediately end.
+Make a damaging attack using the normal attack rules. If your attack exceeds your target defense by 10 or more, then any boons being sustained by your target immediately end.
 
 #### Superior Action
 


### PR DESCRIPTION
`Disrupting Attack` should follow the same rules as an `Exceptional Success`, i.e. `10 over defense` instead of `10+ damage`.