### PR TITLE
Clarify Fatigue tier 2

### DIFF
--- a/banes/banes.yml
+++ b/banes/banes.yml
@@ -225,7 +225,7 @@
     This bane has multiple tiers which are applied in succession. Each time this bane is inflicted, if it is already in effect on the target, the severity escalates by one level.<br/>
     <ul>
     <li>Level 1 - The target has Disadvantage 1 on all non-attack action rolls.</li>
-    <li>Level 2 - The target loses their attribute bonus to their defense scores (Agility for Guard, Fortitude and Will for Toughness, Will and Presence for Resolve). They retain any armor, extraordinary, or feat bonuses.</li>
+    <li>Level 2 - The target loses their attribute bonuses to their defense scores (Agility and Might for Guard, Fortitude and Will for Toughness, Will and Presence for Resolve). They retain any armor, extraordinary, or feat bonuses.</li>
     <li>Level 3 - The target has Disadvantage 1 on all attack rolls.</li>
     <li>Level 4 - The target is affected by the slowed bane, reducing it's speed to 10'. This instance of the slowed bane cannot be resisted as normal. It persists until the fatigue is removed.</li>
     <li>Level 5 - The target loses consciousness and is helpless. Being forced into a state of rest, one level of fatigue will be removed automatically after 24 hours, unless circumstances prevent the target from resting peacefully.</li>


### PR DESCRIPTION
Added losing the Might bonus to Guard. If it's not supposed to be lost, writing "The target loses their attribute bonuses to their defense scores" is unclear.