### PR TITLE
Apostrophe Fix 

### DIFF
--- a/banes/banes.yml
+++ b/banes/banes.yml
@@ -48,7 +48,7 @@
       <li><strong>Power Level 6</strong> - You can Major Charm creatures of humanoid intelligence.</li>
       </ul>
   special: |
-    While most banes last until the target actively attempts to resist it, this bane prevents the target from being aware of their affliction and thus prevents them from actively attempting to break free. However, the targets true mind is magically suppressed but fights to regain control. As such, at the end of each of it’s turns, the target receives a Resist roll as a free action to break free from the effect. When your target succeeds at a resist roll against this bane, they become to immune to all subsequent attempts by you to inflict the bane for the next 24 hours.
+    While most banes last until the target actively attempts to resist it, this bane prevents the target from being aware of their affliction and thus prevents them from actively attempting to break free. However, the targets true mind is magically suppressed but fights to regain control. As such, at the end of each of it's turns, the target receives a Resist roll as a free action to break free from the effect. When your target succeeds at a resist roll against this bane, they become to immune to all subsequent attempts by you to inflict the bane for the next 24 hours.
 - !
   name: Deafened
   tags:
@@ -86,11 +86,11 @@
   invocationTime: 1 Major Action
   duration: Resist ends (special) (Fail x 3 = Permanent)
   description: |
-    Utilizing either incredible precision or the power of entropy, the target’s life force is snuffed out completely. The most deadly assassins and most powerful necromancers are known for such legendary skill at snuffing out life.
+    Utilizing either incredible precision or the power of entropy, the target's life force is snuffed out completely. The most deadly assassins and most powerful necromancers are known for such legendary skill at snuffing out life.
   effect: |
-    You attempt to completely snuff the life force of your target. There is a brief window of time in which the target can attempt to resist this extinguishing force, but once that window closes, the death is permanent and can only be reversed if the GM allows a special mission to use rare technology or long-forgotten magic to restore the target. When the bane is initially applied, the target is immobile (can’t move from their current space) and unconscious. They have disadvantage 5 on all perception rolls, and are incapable of moving. As a result of being completely incapable of movement, an incapacitated character can be the victim of a finishing blow.
+    You attempt to completely snuff the life force of your target. There is a brief window of time in which the target can attempt to resist this extinguishing force, but once that window closes, the death is permanent and can only be reversed if the GM allows a special mission to use rare technology or long-forgotten magic to restore the target. When the bane is initially applied, the target is immobile (can't move from their current space) and unconscious. They have disadvantage 5 on all perception rolls, and are incapable of moving. As a result of being completely incapable of movement, an incapacitated character can be the victim of a finishing blow.
   special: |
-    While most banes last until the target actively attempts to resist it, this bane prevents the target from being aware of their affliction and thus prevents them from actively attempting to break free. However, the targets body fights to regain consciousness and resist the pending death. As such, at the end of each of it’s turns, the target receives a Resist roll as a free action to break free from the effect. Whereas 3 failed resist rolls would usually persist the effects of the bane, this bane extinguishes the life force of the target on 3 failed saves, thus it is permanent. When your target succeeds at a resist roll against this bane, they become immune to all subsequent attempts by you to inflict the bane for the next 24 hours.
+    While most banes last until the target actively attempts to resist it, this bane prevents the target from being aware of their affliction and thus prevents them from actively attempting to break free. However, the targets body fights to regain consciousness and resist the pending death. As such, at the end of each of it's turns, the target receives a Resist roll as a free action to break free from the effect. Whereas 3 failed resist rolls would usually persist the effects of the bane, this bane extinguishes the life force of the target on 3 failed saves, thus it is permanent. When your target succeeds at a resist roll against this bane, they become immune to all subsequent attempts by you to inflict the bane for the next 24 hours.
 - !
   name: Demoralized
   tags:
@@ -159,7 +159,7 @@
     Whether through wrestling it from your opponent, forcefully knocking it out of their hand, skilfully parrying a weapon, a precise nerve strike, magical summoning of vines, etc., heating or chilling an item in their hands, giving a mental command, weakening the muscles they use to grip, or warping the shape of the item, you force an opponent to lose control of an object they are holding.
   effect: |
     <ul>
-    <li><strong>Power Level 3</strong> - You force another character to drop an object they are holding. Choose a location within 15’ of the target, the item ends up there.
+    <li><strong>Power Level 3</strong> - You force another character to drop an object they are holding. Choose a location within 15' of the target, the item ends up there.
     </li>
     <li><strong>Power Level 6</strong> - As an alternative to moving the item, you can choose to assume control of it. If you do, you are now the wielder. For the wielder to regain control, they can react with a Disarmed bane of their own to counter the effect or make an attribute (typically Might) roll with a Challenge Rating equal to 10 + 2 x the attribute score you used to disarm the item.
     </li>
@@ -183,7 +183,7 @@
   effect: |
     The dominated bane manifests at two levels: lesser and greater.
     <strong>Lesser Domination</strong> - the target obeys a one word command until the end of their next turn.
-    <strong>Greater Domination</strong> - The target's every action and move is under your control. Unlike the charmed bane, characters under the effect of domination lose control of their actions. Their minds, however, can think freely, leaving them effectively trapped in their own body. They cannot take action of any kind (except thought) unless it is ordered by you. Every action which the attacker orders the afflicted character to perform which is in extreme violation of their nature gives the target a Resist roll as a free action to break free from the effect. The attacker does not gain special access to the target’s mind and so can only order the character to perform actions that they think or know (from prior knowledge) that the character is capable of. Lastly, each mental order that the attacker gives to the target is a major action, however the order can be a series of verbal commands like “Attack enemy X unless someone comes through the door, in which case flee.”. The dominated creature will continue to obey the last mental command they were given until you give a new command. Only one such command can be active at a given time, so giving a new command cancels all previous ones.
+    <strong>Greater Domination</strong> - The target's every action and move is under your control. Unlike the charmed bane, characters under the effect of domination lose control of their actions. Their minds, however, can think freely, leaving them effectively trapped in their own body. They cannot take action of any kind (except thought) unless it is ordered by you. Every action which the attacker orders the afflicted character to perform which is in extreme violation of their nature gives the target a Resist roll as a free action to break free from the effect. The attacker does not gain special access to the target's mind and so can only order the character to perform actions that they think or know (from prior knowledge) that the character is capable of. Lastly, each mental order that the attacker gives to the target is a major action, however the order can be a series of verbal commands like “Attack enemy X unless someone comes through the door, in which case flee.”. The dominated creature will continue to obey the last mental command they were given until you give a new command. Only one such command can be active at a given time, so giving a new command cancels all previous ones.
       <ul>
       <li><strong>Power Level 3</strong> - You can target creatures of subhuman intelligence (animals, some elementals, certain undead, etc.) with Lesser Domination.</li>
       <li><strong>Power Level 5</strong> - You can target creatures of human intelligence or better with Lesser Domination. You can target creatures of subhuman intelligence (animals, some elementals, etc.) with Greater Domination.</li>
@@ -327,9 +327,9 @@
   invocationTime: 1 Major Action
   duration: Resist ends (Fail x 3 = 1 minute)
   description: |
-    Incapacitation is a catch-all for a variety of effects, including total paralysis, sleep, petrification, poisoning, being knocked out, or fainting. Examples of possible causes of this bane include a martial artist’s paralyzing strike, an enchanter's magical song of sleep, paralysis by poison, fainting from extreme heat, suffocation, and the gaze of a medusa.
+    Incapacitation is a catch-all for a variety of effects, including total paralysis, sleep, petrification, poisoning, being knocked out, or fainting. Examples of possible causes of this bane include a martial artist's paralyzing strike, an enchanter's magical song of sleep, paralysis by poison, fainting from extreme heat, suffocation, and the gaze of a medusa.
   effect: |
-    The target is immobile (can’t move from their current space) and unconscious. They have disadvantage 5 on all perception rolls and are incapable of moving. As a result of being completely incapable of movement, an incapacitated character can be the victim of a finishing blow. <ul><li><strong>Power Level 5</strong> - The effect can be broken by a moderate disruption like a firm shove, a kick, glass of water, loud bang, etc.</li><li><strong>Power Level 7</strong> - The effect can only be broken if the target takes 1 point of damage.</li><li><strong>Power Level 9</strong> - The effect cannot be disrupted by external forces, only the afflicted character’s successful resist roll can end the effect.</li></ul>
+    The target is immobile (can't move from their current space) and unconscious. They have disadvantage 5 on all perception rolls and are incapable of moving. As a result of being completely incapable of movement, an incapacitated character can be the victim of a finishing blow. <ul><li><strong>Power Level 5</strong> - The effect can be broken by a moderate disruption like a firm shove, a kick, glass of water, loud bang, etc.</li><li><strong>Power Level 7</strong> - The effect can only be broken if the target takes 1 point of damage.</li><li><strong>Power Level 9</strong> - The effect cannot be disrupted by external forces, only the afflicted character's successful resist roll can end the effect.</li></ul>
   special: |
     While most banes last until the target actively attempts to resist it, this bane prevents the target from being aware of their affliction and thus prevents them from actively attempting to break free. However, the targets body fights to regain consciousness. As such, at the end of each of its turns, the target receives a resist roll as a free action to break free from the effect. When your target succeeds at a resist roll against this bane, they become to immune to all subsequent attempts by you to inflict the bane for the next hour.
 - !
@@ -374,7 +374,7 @@
     This bane confers no special ability to know about a target's memory. The invoker must be aware of the memory either from rumor, personal knowledge, prescience, or other means.
     <ul>
     <li><strong>Power Level 5</strong> - You temporarily modify a minor aspect of the target's memory. The target automatically regains the lost memory and realizes their confusion 1 hour later.</li>
-    <li><strong>Power Level 6</strong> - You permanently erase or alter the last 5 minutes of the target’s memory. The target does not know what happened during this time outside of the memories you feed them (including having seen you, if they did). Multiple uses of this bane progressively erase consecutive 5 minute increments.</li>
+    <li><strong>Power Level 6</strong> - You permanently erase or alter the last 5 minutes of the target's memory. The target does not know what happened during this time outside of the memories you feed them (including having seen you, if they did). Multiple uses of this bane progressively erase consecutive 5 minute increments.</li>
     <li><strong>Power Level 8</strong> - Instead of the immediate past, you can erase or alter memories from any time.</li>
     </ul>
   special: |
@@ -398,11 +398,11 @@
   description: Fortune tellers, psychics, and mentalists all use mind dredge to peer into the minds of others.
   effect: |
     <ul>
-    <li><strong>Power Level 2</strong> - This power may only target creatures of animal intelligence or lower. You gain access to the target’s current thoughts.</li>
-    <li><strong>Power Level 4</strong> - This power may target creatures of any intelligence. You gain access to the target’s current thoughts.</li>
-    <li><strong>Power Level 6</strong> - This power may target creatures of any intelligence. You gain access to the target’s current thoughts as well as its recent memories. Initially, you may probe 1 day into the past. For every round that the bane persists, you gain access access to an additional day’s worth of memories.</li>
-    <li><strong>Power Level 8</strong> - This power may target creatures of any intelligence. You gain access to the target’s current thoughts as well as its distant memories. Initially, you may probe 1 year into the past. For every round that the bane persists, you gain access access to an additional year’s worth of memories. Alternatively, you may choose to gain the memories associated with a particular place, object, or event.</li>
-    <li><strong>Power Level 9</strong> - This power may target creatures of any intelligence. You gain access to the target’s current thoughts as well as all of its memories, without limitation by time. Alternatively, you may choose to gain the memories associated with a particular place, object, or event. </li>
+    <li><strong>Power Level 2</strong> - This power may only target creatures of animal intelligence or lower. You gain access to the target's current thoughts.</li>
+    <li><strong>Power Level 4</strong> - This power may target creatures of any intelligence. You gain access to the target's current thoughts.</li>
+    <li><strong>Power Level 6</strong> - This power may target creatures of any intelligence. You gain access to the target's current thoughts as well as its recent memories. Initially, you may probe 1 day into the past. For every round that the bane persists, you gain access access to an additional day's worth of memories.</li>
+    <li><strong>Power Level 8</strong> - This power may target creatures of any intelligence. You gain access to the target's current thoughts as well as its distant memories. Initially, you may probe 1 year into the past. For every round that the bane persists, you gain access access to an additional year's worth of memories. Alternatively, you may choose to gain the memories associated with a particular place, object, or event.</li>
+    <li><strong>Power Level 9</strong> - This power may target creatures of any intelligence. You gain access to the target's current thoughts as well as all of its memories, without limitation by time. Alternatively, you may choose to gain the memories associated with a particular place, object, or event. </li>
     </ul>
   special: |
     When your target succeeds at a resist roll against this bane, they become to immune to all subsequent attempts by you to inflict the bane for the next 24 hours.
@@ -432,7 +432,7 @@
     You nullify boons affecting the target of a maximum Power Level equal to the Power Level of this bane. The Power Level at which you invoke this bane determines the types of effects you can nullify, as follows:
     <ul>
       <li><strong>Power Level 1</strong> - You can cancel boons that must be actively invoked. In addition, the target cannot invoke that boon again for 1 minute.</li>
-      <li><strong>Power Level 6</strong> - You can cancel boons that are permanent, passive, or inherent to the target (e.g. the invisibility of a Will o’ Wisp). In the absence of other rules, assume that the target can re-activate the boon as a major action.</li>
+      <li><strong>Power Level 6</strong> - You can cancel boons that are permanent, passive, or inherent to the target (e.g. the invisibility of a Will o' Wisp). In the absence of other rules, assume that the target can re-activate the boon as a major action.</li>
     </ul>
 - !
   name: Persistent Damage
@@ -458,7 +458,7 @@
   description: |
     Whether by setting the target ablaze, covering them in acid, slicing an artery, or cursing them with a wasting disease, you inflict them with a lasting and recurring source of damage.
   effect: |
-    At the beginning of the target's turn, before they take any actions, the target suffers damage determined by the power level of the bane. This damage automatically bypasses the afflicted character’s defenses but it can be reduced by any resistance to damage of a certain type (see the Resistance boon). Like all dice rolls, these dice explode.
+    At the beginning of the target's turn, before they take any actions, the target suffers damage determined by the power level of the bane. This damage automatically bypasses the afflicted character's defenses but it can be reduced by any resistance to damage of a certain type (see the Resistance boon). Like all dice rolls, these dice explode.
     <ul>
       <li><strong>Power Level 2</strong> - 1d4 damage per round.</li>
       <li><strong>Power Level 4</strong> - 1d6 damage per round.</li>
@@ -646,7 +646,7 @@
   description: |
     Silence overcomes the target, whether from the warping of sound around the target, or from a physical effect like strangulation or suffocation.
   effect: |
-    If Might, Agility, or Entropy is used to inflict this bane, then the character is suffering strangulation and unable to speak. If the bane is inflicted using Alteration, then all sound within 5’ of the target is magically suppressed, making their footsteps and the usual clank of belongings they are carrying inaudible.
+    If Might, Agility, or Entropy is used to inflict this bane, then the character is suffering strangulation and unable to speak. If the bane is inflicted using Alteration, then all sound within 5' of the target is magically suppressed, making their footsteps and the usual clank of belongings they are carrying inaudible.
 - !
   name: Slowed
   tags:
@@ -671,7 +671,7 @@
   description: |
     The target's movement is impaired, either by extreme cold, prolonged heat, poison, or injury to one or both legs.
   effect: |
-    The afflicted target’s speed is reduced to half it's current speed, rounded down to the nearest 5' increment. This applies to all movement that is physical (flight, walking, climbing, etc.). If the target is currently under a magical effect that increases speed, the two effects are canceled for the duration that both affect the target.
+    The afflicted target's speed is reduced to half it's current speed, rounded down to the nearest 5' increment. This applies to all movement that is physical (flight, walking, climbing, etc.). If the target is currently under a magical effect that increases speed, the two effects are canceled for the duration that both affect the target.
 - !
   name: Stunned
   tags:
@@ -710,11 +710,11 @@
   invocationTime: 1 Major Action
   duration: Resist ends (Fail x 3 = 1 minute)
   description: |
-    The stupefied bane has examples in many stories and legends: a vampire’s eyes, a siren's song, and a nymph's beauty are all known to cast a stupor upon weak-willed mortals. Being stupefied causes the character to be lulled into a false sense of security, tranquility, and pacifism.
+    The stupefied bane has examples in many stories and legends: a vampire's eyes, a siren's song, and a nymph's beauty are all known to cast a stupor upon weak-willed mortals. Being stupefied causes the character to be lulled into a false sense of security, tranquility, and pacifism.
   effect: |
-    The target is in a state of mental fog, lowering their mental defenses. While stupefied, the character’s Resolve defense is reduced to 10. In addition, the character has the approximate intelligence of a child. If attacked, it will defend itself until the attack ceases using its natural weapons, but the target will never employ any kind of complex tactic or ability, such as spellcasting. If the target sees fire, it will run away. If it feels pain, it will flee.
+    The target is in a state of mental fog, lowering their mental defenses. While stupefied, the character's Resolve defense is reduced to 10. In addition, the character has the approximate intelligence of a child. If attacked, it will defend itself until the attack ceases using its natural weapons, but the target will never employ any kind of complex tactic or ability, such as spellcasting. If the target sees fire, it will run away. If it feels pain, it will flee.
   special: |
-    While most banes last until the target actively attempts to resist it, this bane prevents the target from actively planning to break free. However, the target's true mind is magically suppressed but fights to regain control. As such, at the end of each of its turns, the target receives a Resist roll as a free action to break free from the effect. Any attack that causes the target mental or physical pain gives the target an additional Resist roll to break free from the bane. Also any action that would startle a wild animal (hit with a rock, slap on the face, etc.) will also trigger a free Resist roll for the target. Unlike other resist rolls, those triggered by damage, fear, and trauma do not count against the target’s typically allowed failures of 3, beyond which the duration of the bane would extend. When your target succeeds at a resist roll against this bane, they become to immune to all subsequent attempts by you to inflict the bane for the next 24 hours.
+    While most banes last until the target actively attempts to resist it, this bane prevents the target from actively planning to break free. However, the target's true mind is magically suppressed but fights to regain control. As such, at the end of each of its turns, the target receives a Resist roll as a free action to break free from the effect. Any attack that causes the target mental or physical pain gives the target an additional Resist roll to break free from the bane. Also any action that would startle a wild animal (hit with a rock, slap on the face, etc.) will also trigger a free Resist roll for the target. Unlike other resist rolls, those triggered by damage, fear, and trauma do not count against the target's typically allowed failures of 3, beyond which the duration of the bane would extend. When your target succeeds at a resist roll against this bane, they become to immune to all subsequent attempts by you to inflict the bane for the next 24 hours.
 - !
   name: Surprised
   tags:

--- a/boons/boons.yml
+++ b/boons/boons.yml
@@ -31,7 +31,7 @@
     Your are able to imbue life or unlife into inanimate material components such as dirt, bones, water, vines, or sand (the materials used are subject to GM discretion). You perform a ritual that lasts 8 hours. At the end of the ritual, make your action roll. If successful, the inanimate form is imbued with sentience. If you used the Creation attribute to invoke this boon, then it is a normal living creature. If you used Entropy, then the creature is undead. You can use this boon to animate existing creatures or undead, such as by creating a live wolf from bones and fur or a zombie from an unearthed tomb. However, you cannot use this boon to animate supernatural creatures, such as dragons or basilisks. Your ability to animate the creature grants no special control or influence over it. Since it was birthed through magic, it has no concept of family, creator, or parent. In the case of aggressive creatures, the GM would handle interaction normally, but there is a strong possibility that the creature would immediately attack its creator.
     The GM, not the player, is responsible for deciding the attributes and abilities of this animated creature and it should follow the guidelines established by the "Simple Build" section for creating NPCs / monsters in Chapter 7: Running the Game.
     <ul>
-    <li><strong>Power Level 6</strong> - You can animate a single creature. Your attribute score must be equal to or greater than the highest attribute score of the creature you’re animating. With a successful invocation, the creature comes into existence with the <strong>Charmed</strong> (Minor Charm) bane already in effect (no roll is required).</li>
+    <li><strong>Power Level 6</strong> - You can animate a single creature. Your attribute score must be equal to or greater than the highest attribute score of the creature you're animating. With a successful invocation, the creature comes into existence with the <strong>Charmed</strong> (Minor Charm) bane already in effect (no roll is required).</li>
     <li><strong>Power Level 8</strong> - You can animate a group of creatures: Either 10 creatures with a max attribute of 2, or 5 creatures with a max attribute of 3, or 2 creatures with a max attribute of 5. In addition, the automatically invoked <strong>Charmed</strong> bane is a Major Charm instead of Minor Charm.</li>
     </ul>
 - !
@@ -213,8 +213,8 @@
     The target is propelled by magical force through the air, with progressively improving speed and agility.
   effect: |
     <ul>
-    <li><strong>Power Level 5</strong> - The target gains a flight speed of 10’ with low maneuverability.</li>
-    <li><strong>Power Level 6</strong> - The target gains a flight speed of 30’ and is highly maneuverable.</li>
+    <li><strong>Power Level 5</strong> - The target gains a flight speed of 10' with low maneuverability.</li>
+    <li><strong>Power Level 6</strong> - The target gains a flight speed of 30' and is highly maneuverable.</li>
     <li><strong>Power Level 8</strong> - The granted flight speed increases to 60'.</li>
     </ul>
     If the boon is dispelled while the target is still in flight, they plummet to the ground immediately.
@@ -658,7 +658,7 @@
   effect: |
     <ul>
     <li><strong>Power Level 3</strong> - You can teleport your target to any unoccupied space within 5 feet per Movement attribute score as long as you can naturally see it. </li>
-    <li><strong>Power Level 5</strong> - Your teleportation range is unchanged, but you can now teleport your target to spaces that you can’t see. If you choose an occupied space, your target lands in the nearest adjacent space (roll randomly to decide if there are multiple options) and your target is stunned for 1 round (a resist roll is not needed to end the effect). </li>
+    <li><strong>Power Level 5</strong> - Your teleportation range is unchanged, but you can now teleport your target to spaces that you can't see. If you choose an occupied space, your target lands in the nearest adjacent space (roll randomly to decide if there are multiple options) and your target is stunned for 1 round (a resist roll is not needed to end the effect). </li>
     <li><strong>Power Level 7</strong> - You can opt to take longer in invoking the boon. If you choose to, for each minute of invocation (delay before making your action roll) you can teleport the target 1 mile, up to a maximum number of miles equal to your Movement attribute score. While the distance is greater, this mode is also dangerous, as a misunderstanding of direction or geography can put your target many miles in an unfavorable direction. You simply choose a direction (relative to your starting location) and teleport your target a number of miles equal to your Movement score. During invocation, you must spend a Focus action each turn until the invocation time passes.</li>
     <li><strong>Power Level 9</strong> - Using the same longer invocation time from Power Level 7, you can now teleport your target to any location without range limit, provided you have personally seen (through magical or normal means) the destination.</li>
     </ul>

--- a/core/SRD.md
+++ b/core/SRD.md
@@ -3,11 +3,11 @@
 
 ## Step 1: Describe Your Character
 
-*Open Legend* is a role playing game, which means your character will need more depth than merely a selection of attributes, feats, perks, and gear that we will learn about in later steps. To make your character come to life, add some of the following details. If you can’t think of anything yet, try to fill in the blanks during your first couple of play sessions as you get to know your character better.
+*Open Legend* is a role playing game, which means your character will need more depth than merely a selection of attributes, feats, perks, and gear that we will learn about in later steps. To make your character come to life, add some of the following details. If you can't think of anything yet, try to fill in the blanks during your first couple of play sessions as you get to know your character better.
 
 **A heroic name.** Be sure to check with your GM to see if they have any particular setting in mind. Phil the Fighter would feel quite out of place next to Therilas Windcaster and Gorion Skullcleaver.
 
-**Your race.** Your decision of race is limited only by your imagination, the setting, and the constraints provided by your GM. A typical fantasy campaign might feature dwarves, elves, halflings, celestials, and dragon-blooded. If you are playing in a futuristic space opera on the fringes of the galaxy, your GM might have several alien races to choose from. Some campaigns, such as a mystery of Lovecraftian horror, might allow only for regular old humans. Really, though, as long as it is approved by your GM, you can play anything you would like, whether that’s a psionic humanoid tiger, a 3-inch tall pixie, or anything in between.
+**Your race.** Your decision of race is limited only by your imagination, the setting, and the constraints provided by your GM. A typical fantasy campaign might feature dwarves, elves, halflings, celestials, and dragon-blooded. If you are playing in a futuristic space opera on the fringes of the galaxy, your GM might have several alien races to choose from. Some campaigns, such as a mystery of Lovecraftian horror, might allow only for regular old humans. Really, though, as long as it is approved by your GM, you can play anything you would like, whether that's a psionic humanoid tiger, a 3-inch tall pixie, or anything in between.
 
 As part of deciding your race, you should also choose your **size**: small, medium, or large. A medium character is roughly the size of an average human. Small creatures range from about 2 - 4 feet in height, while large creatures are about 7 - 10 feet tall. A large creature occupies a 10'x10' square in combat and has a 10' reach (see Chapter 6: Combat for details). The GM may assign advantage or disadvantage during situations in which your size is relevant. For example, small creatures may gain advantage on rolls to hide and receive disadvantage on rolls to kick down a door. Likewise, large creatures might suffer disadvantage on attack rolls when fighting in confined spaces but gain advantage on rolls to intimidate smaller creatures.
 
@@ -15,9 +15,9 @@ At the GM's discretion, you may choose to be even smaller or larger than the siz
 
 **Two exceptional physical traits.** Think of the first two features that other characters notice when they see you. Do your eyes glow red when you are angry? Are you seven feet tall? Is your hair a rainbow hue?
 
-**Two defining social traits.** Maybe you stutter when you’re nervous. Maybe you don’t trust anyone until they’ve proven themselves to you. Or, perhaps, you are a winsome bard who almost always talks in sing-song. Your two social traits should be characteristics that others will learn shortly after getting to know you.
+**Two defining social traits.** Maybe you stutter when you're nervous. Maybe you don't trust anyone until they've proven themselves to you. Or, perhaps, you are a winsome bard who almost always talks in sing-song. Your two social traits should be characteristics that others will learn shortly after getting to know you.
 
-**A secret.** Your secret is something that other characters probably won’t find out about until they’ve gotten to know you quite well. It’s also a seed for great adventure that the GM can weave into his campaign.
+**A secret.** Your secret is something that other characters probably won't find out about until they've gotten to know you quite well. It's also a seed for great adventure that the GM can weave into his campaign.
 
 +++ {.CalloutInformation}
 
@@ -25,7 +25,7 @@ Before Volkor changed his name and began wandering the land as a barbarian sells
 
 * * * * *
 
-Sir Thomas Tuckburrough served as an assassin for the local thieves guild until a job went bad and he murdered an innocent child--that’s when he began his road to the priesthood.
+Sir Thomas Tuckburrough served as an assassin for the local thieves guild until a job went bad and he murdered an innocent child--that's when he began his road to the priesthood.
 
 * * * * *
 
@@ -36,7 +36,7 @@ Most meaningful tasks that a character attempts in *Open Legend* will be determi
 
 To determine the outcome, you roll 1d20 plus any bonus dice granted by your character's attribute that is most relevant to the task. Any dice that roll the maximum possible explode, which means you can roll them again and add the new total to your action roll as well. Continue rerolling dice until none of them explode.
 
-Add all of the dice together to find your total action roll. If your total is equal to or greater than the action’s Challenge Rating, then you succeed. Otherwise, the GM decides that you either succeed with a twist or fail in a way that allows the story to progress.
+Add all of the dice together to find your total action roll. If your total is equal to or greater than the action's Challenge Rating, then you succeed. Otherwise, the GM decides that you either succeed with a twist or fail in a way that allows the story to progress.
 
 \ \
 
@@ -59,12 +59,12 @@ Add all of the dice together to find your total action roll. If your total is eq
 
 ## Step 2: Choose Attributes
 
-Attributes are the backbone of every character in *Open Legend*. They define what your character can and can’t do--the spheres they excel in, as well as their greatest weaknesses. Whenever your character attempts a heroic action in Open Legend, you’ll look to your attributes to see how well you succeed or fail.
+Attributes are the backbone of every character in *Open Legend*. They define what your character can and can't do--the spheres they excel in, as well as their greatest weaknesses. Whenever your character attempts a heroic action in Open Legend, you'll look to your attributes to see how well you succeed or fail.
 
 In *Open Legend*, attributes are divided into four categories: physical,
 social, mental, and extraordinary.
 
-A character’s skill with each attribute is expressed as a score from 0 (completely unpracticed) to 9 (superhuman). A character cannot use an extraordinary attribute if they have a score of zero.
+A character's skill with each attribute is expressed as a score from 0 (completely unpracticed) to 9 (superhuman). A character cannot use an extraordinary attribute if they have a score of zero.
 
 The average commoner or craftsmen usually has scores ranging from 1 - 3 in several physical, social, and mental attributes. Extraordinary attributes are generally reserved for characters of power and note.
 
@@ -93,7 +93,7 @@ The Attributes at a Glance tables provide a quick overview of some of the common
 | | |
 | - | - |
 | **Learning** | Recall facts about history, arcane magic, the natural world, etc. |
-| **Logic** | Solve riddles, decipher a code, improvise a tool, understand the enemy’s strategy, find a loophole |
+| **Logic** | Solve riddles, decipher a code, improvise a tool, understand the enemy's strategy, find a loophole |
 | **Perception** | Sense ulterior motives, track someone, catch a gut feeling, spot a hidden foe, find a secret door |
 | **Will** | Maintain your resolve, overcome adversity, resist torture, stay awake on watch, stave off insanity |
 
@@ -127,7 +127,7 @@ The Attributes at a Glance tables provide a quick overview of some of the common
 | **Prescience** | See the future, read minds or auras, detect magic or evil, scry, communicate with extraplanar entities |
 | **Protection** | Protect from damage, break mental influence, dispel magic, bind demons |
 
-In *Open Legend*, you get to define your character’s strengths and weaknesses by choosing the attributes that fit your character concept. Described below are several methods by which you can assign your attributes.
+In *Open Legend*, you get to define your character's strengths and weaknesses by choosing the attributes that fit your character concept. Described below are several methods by which you can assign your attributes.
 
 ### Quick Build
 
@@ -148,7 +148,7 @@ If you are new to roleplaying games, or are just looking to get your character b
 
 ### Custom Build
 
-If you would like more control over your attributes, you can purchase them to create your own set. With this method, at first level, you have a budget of 40 attribute points to spend, and the cost of each score is defined in the Purchasing Attributes table. The highest any score can reach at first level is 5, and you don’t have to spend all of your points at character creation.
+If you would like more control over your attributes, you can purchase them to create your own set. With this method, at first level, you have a budget of 40 attribute points to spend, and the cost of each score is defined in the Purchasing Attributes table. The highest any score can reach at first level is 5, and you don't have to spend all of your points at character creation.
 
 
 ### Purchasing Attributes
@@ -168,7 +168,7 @@ If you would like more control over your attributes, you can purchase them to cr
 
 ### Record Attribute Dice
 
-Every attribute score above 0 grants you bonus dice to increase your chance of success. Consult the Attribute Dice table for each of your attributes and record the appropriate dice. (You’ll learn what to do with these dice later on.)
+Every attribute score above 0 grants you bonus dice to increase your chance of success. Consult the Attribute Dice table for each of your attributes and record the appropriate dice. (You'll learn what to do with these dice later on.)
 
 ### Attribute Dice
 
@@ -211,7 +211,7 @@ When an enemy tries to attack you--whether with the shot of a rifle, a deft swor
 | Resolve = 10 + Presence + Will  |
 
 
-**Resolve** represents your character’s ability to resist mental domination and stand brave in the face of danger. Enemies who wish to charm you, deceive you with illusions, or frighten you must target your resolve.
+**Resolve** represents your character's ability to resist mental domination and stand brave in the face of danger. Enemies who wish to charm you, deceive you with illusions, or frighten you must target your resolve.
 
 
 \NextTableColumns{OCT{1}}
@@ -229,7 +229,7 @@ When an enemy tries to attack you--whether with the shot of a rifle, a deft swor
 
 ## Step 4: Purchase Feats
 
-While your character’s attributes define his skill at accomplishing
+While your character's attributes define his skill at accomplishing
 heroic tasks, his **feats** are what make him unique among other
 characters. Feats allow you to customize your character, granting him
 the ability to accomplish specific actions exceptionally well.
@@ -255,12 +255,12 @@ In addition to the descriptive details you have just created, you may also choos
 
 Perks are characteristics that describe very specific skills, attitudes, backgrounds, or opportunities that tend to give your character the upper hand in certain situations. For example, maybe you are a noble and thus able to draw favors from powerful political figures, or perhaps you once served as mechanic on a starship and those technical skills still help you out in your adventuring life today.
 
-Flaws are your Achilles’ heel. They are weaknesses that your enemies can exploit or character deficits that always seem to hold you back at just the wrong moment. Maybe you are stubborn as a mule and won’t accept a compromise under any circumstances. Perhaps your greed tends to get the best of you, and your love of coin will even trump your loyalty to your friends. Your flaws might even be physical in nature: you’re blind, missing an arm, or suffer from a wounded knee that slows you down.
+Flaws are your Achilles' heel. They are weaknesses that your enemies can exploit or character deficits that always seem to hold you back at just the wrong moment. Maybe you are stubborn as a mule and won't accept a compromise under any circumstances. Perhaps your greed tends to get the best of you, and your love of coin will even trump your loyalty to your friends. Your flaws might even be physical in nature: you're blind, missing an arm, or suffer from a wounded knee that slows you down.
 
 
 ### Activating Perks
 
-Perks provide very specific bonuses or effects in specific situations. Your perk description will explain exactly what your perk does and how often it can be activated. Some perks can be used whenever the situation merits while others are more limited. If the use of a perk relies on a situation being relevant to the sphere of influence of the perk, the GM has the final say as to whether the perk applies or not. For example, the *profession* perk provides advantage 1 to any non-combat action rolls related to your chosen profession. If a character wants to use their *profession: hunter* perk to gain advantage on a roll to track an orc, the GM would decide whether or not the PC’s experience tracking game was relevant enough to aid in the hunt for a humanoid.
+Perks provide very specific bonuses or effects in specific situations. Your perk description will explain exactly what your perk does and how often it can be activated. Some perks can be used whenever the situation merits while others are more limited. If the use of a perk relies on a situation being relevant to the sphere of influence of the perk, the GM has the final say as to whether the perk applies or not. For example, the *profession* perk provides advantage 1 to any non-combat action rolls related to your chosen profession. If a character wants to use their *profession: hunter* perk to gain advantage on a roll to track an orc, the GM would decide whether or not the PC's experience tracking game was relevant enough to aid in the hunt for a humanoid.
 
 ### Activating Flaws
 
@@ -270,13 +270,13 @@ You may not gain a legend point from the same flaw more than once per game sessi
 
 To activate a flaw, you should intentionally make a disadvantageous choice based on your flaw that creates an interesting or tense moment in the plot. When you do so, let your GM know that you are activating your flaw and describe how it is hindering your efforts or influencing your decisions. If the GM approves that your flaw is creating a significant disadvantage and advancing the story, you receive one legend point. Sometimes, the GM may recognize that you are roleplaying a flaw without you having to overtly activate it. In such cases, the GM may award you with a legend point as well.
 
-The type of hindrance caused by activating a flaw should be more than a simple reduced chance of success. Good examples of activating a flaw include putting yourself or an ally in danger, making a bad decision, wasting a resource, and missing out on an opportunity, among others. It’s also important to note that a good use of a flaw makes something new and interesting happen in the story rather than ending the narrative. For example, instead of activating a flaw to miss an attack, you might target an ally. Or, rather than activating a flaw to fail to find a secret door, you might make so much noise in your search that you attract unwanted attention.
+The type of hindrance caused by activating a flaw should be more than a simple reduced chance of success. Good examples of activating a flaw include putting yourself or an ally in danger, making a bad decision, wasting a resource, and missing out on an opportunity, among others. It's also important to note that a good use of a flaw makes something new and interesting happen in the story rather than ending the narrative. For example, instead of activating a flaw to miss an attack, you might target an ally. Or, rather than activating a flaw to fail to find a secret door, you might make so much noise in your search that you attract unwanted attention.
 
 ### Gaining Perks and Flaws
 
 At character creation, you may select up to two perks and two flaws, and you do not have to select any. Throughout your adventures, the GM may assign you additional perks and flaws as the natural results of your deeds. For example, if your party spends several months on board a ship, the GM may reward everyone with the *profession: sailor* perk. Likewise, if you are subjected to horrible chemical burns as part of a laboratory explosion, the GM might assign you the *physical deformity* flaw to describe your scarred face.
 
-You too, may decide to adopt new perks or flaws with the GM’s approval as your character’s personality and background develop through play. Perhaps a series of encounters with powerful forces leads you to take on the *cowardly* flaw. Or maybe you spend significant downtime between adventures training with the local weaponsmith and would like to gain the *artisan* perk. The GM is the final arbiter for deciding when and under what circumstances you may choose new perks and flaws.
+You too, may decide to adopt new perks or flaws with the GM's approval as your character's personality and background develop through play. Perhaps a series of encounters with powerful forces leads you to take on the *cowardly* flaw. Or maybe you spend significant downtime between adventures training with the local weaponsmith and would like to gain the *artisan* perk. The GM is the final arbiter for deciding when and under what circumstances you may choose new perks and flaws.
 
 ### Designing Your Own Perks and Flaws
 
@@ -329,7 +329,7 @@ You serve a higher being and have earned their protection. Once per game session
 
 #### Divine Insight
 
-You possess a supernatural connection to a deity, demi-god, or other divine being which grants you otherworldly insight. Once per game session, you can choose a topic relevant to the story. The GM shares some information about that topic which might be useful. If you’ve just failed a *Learning* attribute roll and use this ability, the GM decides whether to give you information related to that roll or to give you knowledge that is completely unrelated.
+You possess a supernatural connection to a deity, demi-god, or other divine being which grants you otherworldly insight. Once per game session, you can choose a topic relevant to the story. The GM shares some information about that topic which might be useful. If you've just failed a *Learning* attribute roll and use this ability, the GM decides whether to give you information related to that roll or to give you knowledge that is completely unrelated.
 
 #### Ear of the Emperor
 
@@ -345,7 +345,7 @@ Your reputation for some outstanding virtue precedes you, and people tend to hol
 
 #### Innocent
 
-Whether from a distant fey ancestry or simply an air of naivety, you possess a childlike quality that can melt even the coldest of hearts. Once per game session, you can leverage your innocence to turn an enemy and cause them to take pity on you. The enemy might choose to look the other way when you’ve done something illegal, forgive a debt you could never pay, or vouch in your favor before the authorities.
+Whether from a distant fey ancestry or simply an air of naivety, you possess a childlike quality that can melt even the coldest of hearts. Once per game session, you can leverage your innocence to turn an enemy and cause them to take pity on you. The enemy might choose to look the other way when you've done something illegal, forgive a debt you could never pay, or vouch in your favor before the authorities.
 
 #### Jack of All Trades
 
@@ -377,7 +377,7 @@ Your keen senses allow you to notice details that others typically miss. Once pe
 
 #### Outlaw
 
-You are part of a criminal network, whether it be a thieves’ guild, band of smugglers, or otherwise. Once per game session, you can call in a favor from a contact within your network to perform a mundane task such as gathering information or arranging safe passage. If the favor puts your contact at risk, they will still perform it but may ask for an equally risky favor from you in return.
+You are part of a criminal network, whether it be a thieves' guild, band of smugglers, or otherwise. Once per game session, you can call in a favor from a contact within your network to perform a mundane task such as gathering information or arranging safe passage. If the favor puts your contact at risk, they will still perform it but may ask for an equally risky favor from you in return.
 
 #### Profession
 
@@ -385,7 +385,7 @@ Choose a specific trade, such as sailor, soldier, or miner. You know everything 
 
 #### Pure-hearted
 
-Any goodly-natured creature you encounter is friendly toward you by default rather than neutral. Circumstances can alter this, but even if rumors or actions you’ve taken would influence a good creature negatively, it remains one step friendlier than it otherwise would have been.
+Any goodly-natured creature you encounter is friendly toward you by default rather than neutral. Circumstances can alter this, but even if rumors or actions you've taken would influence a good creature negatively, it remains one step friendlier than it otherwise would have been.
 
 #### Resilient
 
@@ -397,7 +397,7 @@ You have lived a life of need, and thus know how to make do when others would go
 
 #### Scent
 
-Your sense of smell is similar to that of a wild beast. As a focus action, you can discern the number and relative location of living creatures within 60’. With an additional focus action you can lock onto a particular scent and maintain its relative location as long as it remains within 60’. Furthermore, you gain advantage 1 on attempts to track a creature if it has left a scent trail.
+Your sense of smell is similar to that of a wild beast. As a focus action, you can discern the number and relative location of living creatures within 60'. With an additional focus action you can lock onto a particular scent and maintain its relative location as long as it remains within 60'. Furthermore, you gain advantage 1 on attempts to track a creature if it has left a scent trail.
 
 #### Scholar
 
@@ -405,23 +405,23 @@ You have spent years studying a particular discipline, such as science, herbalis
 
 #### Silver Tongue
 
-You have practiced the ways of sneaking hidden charms and subliminal messages within everyday conversation. Once per session, when you converse with an intelligent creature for at least five minutes, you will learn one useful secret of the GM’s choosing about the creature.
+You have practiced the ways of sneaking hidden charms and subliminal messages within everyday conversation. Once per session, when you converse with an intelligent creature for at least five minutes, you will learn one useful secret of the GM's choosing about the creature.
 
 #### Stone Sense
 
-While underground you may fail to find what you’re looking for, but you can never be truly lost. You can always find your way back to the entrance through which you entered. Furthermore, you have advantage 1 on any action rolls in which a familiarity with underground environments would prove helpful, such as attempts to identify the risk of a cave in or to find a secret passage within a cavern.
+While underground you may fail to find what you're looking for, but you can never be truly lost. You can always find your way back to the entrance through which you entered. Furthermore, you have advantage 1 on any action rolls in which a familiarity with underground environments would prove helpful, such as attempts to identify the risk of a cave in or to find a secret passage within a cavern.
 
 #### Street Rat
 
-You were raised on the streets or at least spent a good deal of time crawling about them. As such, you know how to navigate urban areas quickly, make yourself unseen, and find a bite to eat when you’re down on your luck. As one of the invisible urchins that crawl the city, you are also quite adept at picking up rumors in taverns and crowded streets.
+You were raised on the streets or at least spent a good deal of time crawling about them. As such, you know how to navigate urban areas quickly, make yourself unseen, and find a bite to eat when you're down on your luck. As one of the invisible urchins that crawl the city, you are also quite adept at picking up rumors in taverns and crowded streets.
 
 #### Vagabond
 
 Having spent significant time fending for yourself in the wilderness, you excel at surviving and navigating in the wild. You always know the direction of true north and you can automatically find enough food to feed yourself plus a number of additional people equal to your Learning attribute score.
 
-#### Warrior’s Code
+#### Warrior's Code
 
-As a veteran warrior, you command respect even from foes. Once per session, you can use this ability to cause an enemy or group of enemies to extend special concessions or favorable treatment toward you via an unspoken warrior’s code. The GM decides what these concessions look like. For example, your enemies might choose to trust you to come quietly and not shackle you, or overlook an insult that would have otherwise have been cause for bloodshed.
+As a veteran warrior, you command respect even from foes. Once per session, you can use this ability to cause an enemy or group of enemies to extend special concessions or favorable treatment toward you via an unspoken warrior's code. The GM decides what these concessions look like. For example, your enemies might choose to trust you to come quietly and not shackle you, or overlook an insult that would have otherwise have been cause for bloodshed.
 
 #### Whisperer of the Wild
 
@@ -437,15 +437,15 @@ Your live with your head in the clouds. You might just be ditzy, or maybe you ju
 
 #### Addiction
 
-The roll of the dice, the smoke of the Black Lotus, or the escape of the virtual reality machine. Whether your addiction is physical, mental, or social, the effect is generally the same: you’ve got an itch that you need to scratch, and you’ll sometimes do reckless or atrocious things to make sure that you can get your fix. You get to decide the nature and severity of your addiction.
+The roll of the dice, the smoke of the Black Lotus, or the escape of the virtual reality machine. Whether your addiction is physical, mental, or social, the effect is generally the same: you've got an itch that you need to scratch, and you'll sometimes do reckless or atrocious things to make sure that you can get your fix. You get to decide the nature and severity of your addiction.
 
 #### Ambitious
 
-You are willing to do anything to get ahead in life and often that means trampling upon other people on your way to the top. When presented with a situation requiring empathy for those beneath you, it’s typical for you to ignore their need. In addition, you may sometimes overreach in your attempts to get ahead, making bold and risky choices that can put you and those close to you in danger.
+You are willing to do anything to get ahead in life and often that means trampling upon other people on your way to the top. When presented with a situation requiring empathy for those beneath you, it's typical for you to ignore their need. In addition, you may sometimes overreach in your attempts to get ahead, making bold and risky choices that can put you and those close to you in danger.
 
 #### Bloodlust
 
-Battle isn’t just a way of life, it is *the* way of life. There isn’t a conflict you’ve encountered that wasn’t best solved with steel, and your allies will have a hard time convincing you otherwise. You are prone to starting fights when they aren’t necessary and prolonging them even after the enemy has surrendered.
+Battle isn't just a way of life, it is *the* way of life. There isn't a conflict you've encountered that wasn't best solved with steel, and your allies will have a hard time convincing you otherwise. You are prone to starting fights when they aren't necessary and prolonging them even after the enemy has surrendered.
 
 
 #### Brash
@@ -470,7 +470,7 @@ You have honed self-preservation into a way of life, and you will do almost anyt
 
 #### Dimwitted
 
-You aren’t the sharpest tack in the box. It’s not just that you weren’t gifted with skill in academia, it’s that you pick up on things pretty slowly overall. With the exception of your areas of expertise, you have a hard time learning new skills, following instructions, and maybe even remembering names.
+You aren't the sharpest tack in the box. It's not just that you weren't gifted with skill in academia, it's that you pick up on things pretty slowly overall. With the exception of your areas of expertise, you have a hard time learning new skills, following instructions, and maybe even remembering names.
 
 #### Disabled
 
@@ -478,22 +478,22 @@ You have some physical deficiency that holds you back in life. You decide the na
 
 #### Greedy
 
-You can’t help it: you just like things. Money, gems, items of power - they beckon you at every turn and you’ll often take great risks and maybe even betray your allies if the monetary reward is great enough. You’re easy to bribe, and you will often push the limits of negotiation or bartering in order to increase your share in the profits, even if it makes you a few enemies.
+You can't help it: you just like things. Money, gems, items of power - they beckon you at every turn and you'll often take great risks and maybe even betray your allies if the monetary reward is great enough. You're easy to bribe, and you will often push the limits of negotiation or bartering in order to increase your share in the profits, even if it makes you a few enemies.
 
 #### Honest
 
-You won’t tell a lie or engage in deceitful speech, even to save your own life or the life of another.
+You won't tell a lie or engage in deceitful speech, even to save your own life or the life of another.
 
 #### Hot Tempered
 Your fuse is short and your explosions are destructive. Sometimes your anger boils slowly over time and other times it erupts completely unexpectedly. But when you do fly off the handle, things rarely go well for you.
 
 #### Illiterate
 
-You can’t read or write, even in languages that you speak fluently.
+You can't read or write, even in languages that you speak fluently.
 
 #### Literal Minded
 
-You struggle with concepts and turns of phrase that are not literally true, such as idioms and metaphors. You might think sorcery is afoot if someone tells you it is “raining cats and dogs”. If a friend exaggerated by saying “I’d kill myself if Melzak were elected Supreme Justice”, you would be genuinely concerned for your friend’s life if Melzak did get elected.
+You struggle with concepts and turns of phrase that are not literally true, such as idioms and metaphors. You might think sorcery is afoot if someone tells you it is “raining cats and dogs”. If a friend exaggerated by saying “I'd kill myself if Melzak were elected Supreme Justice”, you would be genuinely concerned for your friend's life if Melzak did get elected.
 
 #### Mood Disorder
 
@@ -501,7 +501,7 @@ You suffer from a psychological condition that directly affects your mood, such 
 
 #### Naive
 
-Whether you are innocent, uninformed, or inexperienced, the results are the same: you are pretty gullible. You get to define the scope of your naivety. For example, maybe you’re a greenhorn from a big city on the east coast, so you are unlearned in the ways of the Wild West. Or maybe your memory was completely wiped out a few weeks ago and you are relearning the rules of civilization, thus your naivety presents itself much more universally.
+Whether you are innocent, uninformed, or inexperienced, the results are the same: you are pretty gullible. You get to define the scope of your naivety. For example, maybe you're a greenhorn from a big city on the east coast, so you are unlearned in the ways of the Wild West. Or maybe your memory was completely wiped out a few weeks ago and you are relearning the rules of civilization, thus your naivety presents itself much more universally.
 
 #### Overt
 
@@ -513,7 +513,7 @@ You are carrying a few extra pounds, and they tend to get in the way at all the 
 
 #### Pacifist
 
-You disdain combat and bloodshed of any kind, and will generally do whatever possible to avoid it. You can decide the extent of your pacifism. You might just revert to violence as a last resort, or you may be so averse to combat that you won’t lift a weapon even in defense of yourself or others.
+You disdain combat and bloodshed of any kind, and will generally do whatever possible to avoid it. You can decide the extent of your pacifism. You might just revert to violence as a last resort, or you may be so averse to combat that you won't lift a weapon even in defense of yourself or others.
 
 #### Phobia
 
@@ -521,7 +521,7 @@ You are terrified and incapable of rational thought when you are presented with 
 
 #### Proud
 
-Some call it an inflated ego. Others call it conceit. But you know that you really are just that good. The rabble are inferior, and you’re not afraid to let them know. Your pride may be a universal sense of self-worth, or it may only manifest itself within certain spheres or situations. For example, your rank in the Royal Star Force leads you to look down upon anyone trained in less illustrious armed forces.
+Some call it an inflated ego. Others call it conceit. But you know that you really are just that good. The rabble are inferior, and you're not afraid to let them know. Your pride may be a universal sense of self-worth, or it may only manifest itself within certain spheres or situations. For example, your rank in the Royal Star Force leads you to look down upon anyone trained in less illustrious armed forces.
 
 #### Psychotic
 
@@ -537,14 +537,14 @@ You suffer from some sort of chronic illness or condition, such as tuberculosis,
 
 #### Socially Awkward
 
-Something about your behavior tends to rub people the wrong way. Perhaps you don’t respect the personal space of others, you tend to ramble in conversation, or share overly personal details. Whatever the nature of your awkwardness, it makes social situations difficult for you at times.
+Something about your behavior tends to rub people the wrong way. Perhaps you don't respect the personal space of others, you tend to ramble in conversation, or share overly personal details. Whatever the nature of your awkwardness, it makes social situations difficult for you at times.
 
 #### Stubborn
-It’s your way or the highway. Maybe not all of the time, but once you’ve made your mind up on an important matter, you won’t budge. You probably won’t even compromise.
+It's your way or the highway. Maybe not all of the time, but once you've made your mind up on an important matter, you won't budge. You probably won't even compromise.
 
 #### Uncoordinated
 
-Your body just doesn’t work well with itself. You have trouble balancing, catching, throwing, and performing similar physical tasks that require dexterity or nimbleness.
+Your body just doesn't work well with itself. You have trouble balancing, catching, throwing, and performing similar physical tasks that require dexterity or nimbleness.
 
 #### Vengeful
 
@@ -557,7 +557,7 @@ You stand for a cause - whether it is a religion, a nation, a code, a way of lif
 
 ## Gaining XP and Leveling Up
 
-As the legend you are creating unfolds and grows in danger and magnitude, your character’s power will grow to match the challenge. This power comes in the form of experience points (or XP), which are rewarded by the GM and allow you to advance in level and gain access to new feats, attributes, banes, and boons.
+As the legend you are creating unfolds and grows in danger and magnitude, your character's power will grow to match the challenge. This power comes in the form of experience points (or XP), which are rewarded by the GM and allow you to advance in level and gain access to new feats, attributes, banes, and boons.
 
 Your total XP earned determines your level, with every 3 XP allowing you to advance to the next level. Your level is used to determine your maximum attribute score as well as to provide a general indication of your power compared to other characters, NPCs, and monsters. Until you reach 5th level, the maximum attribute score is 5. From levels 6 to 9, the maximum is equal to your level.
 
@@ -614,7 +614,7 @@ The complete list of available feats can be found on the [Open Legend Website](h
 
 ### New Hit Points
 
-In Open Legend, attributes are the means by which your hit points increase. If you want your character to be able to take more hits, increase either your Fortitude, Presence, or Will attribute. As outlined in the default hit point formula, you’ll gain 2 hit points each time you raise any of those attributes by one.
+In Open Legend, attributes are the means by which your hit points increase. If you want your character to be able to take more hits, increase either your Fortitude, Presence, or Will attribute. As outlined in the default hit point formula, you'll gain 2 hit points each time you raise any of those attributes by one.
 
 
 
@@ -626,7 +626,7 @@ interpret the results.
 ## When to Roll the Dice
 
 *Open Legend* is about creating great stories full of epic moments of heroism, and you roll dice to determine the outcome of those moments. In short, you only need to make action rolls when the outcome of the intended action plays a significant role in the story. In combat, for
-example, you’ll be making plenty of action rolls to clash blades, sling spells, shoot blasters, and leap over treacherous chasms. But you don’t need to roll a Persuasion check every time you go to buy something from the bazaar, and you don’t need to roll Logic to remember where you left your multi-pass.
+example, you'll be making plenty of action rolls to clash blades, sling spells, shoot blasters, and leap over treacherous chasms. But you don't need to roll a Persuasion check every time you go to buy something from the bazaar, and you don't need to roll Logic to remember where you left your multi-pass.
 
 *Open Legend* includes a number of Extraordinary attributes that can be used to represent futuristic theoretical science, magic, or inherent supernatural capabilities. For all other types of attribute, you can make an action roll with an attribute score of zero, but Extraordinary attributes require a minimum score of 1 in order to attempt a roll.
 
@@ -656,11 +656,11 @@ If you look back to the Core Mechanic, you can see that a simple failure is not 
 
 ### Keep It Simple: Every Roll Matters for the GM
 
-The “every roll matters” rule was designed to make player actions meaningful to the story whether they succeed or fail. It recognizes the fact that static pass/fail checks aren’t particularly fun for players. But “every roll matters” also adds an extra layer of complexity to the game because it requires the GM to make on-the-fly interpretations.
+The “every roll matters” rule was designed to make player actions meaningful to the story whether they succeed or fail. It recognizes the fact that static pass/fail checks aren't particularly fun for players. But “every roll matters” also adds an extra layer of complexity to the game because it requires the GM to make on-the-fly interpretations.
 
 **So when the GM makes a roll**, a success is a success and a failure is a failure.
 
-This is for the sake of simplicity and fun. When a player fails a roll, it’s not very fun if something doesn’t come out of it. When the GM fails a roll, though, there is usually much rejoicing at the table.
+This is for the sake of simplicity and fun. When a player fails a roll, it's not very fun if something doesn't come out of it. When the GM fails a roll, though, there is usually much rejoicing at the table.
 
 ### Group Action Rolls
 
@@ -670,9 +670,9 @@ The GM always has the final say as to when a group action roll is called for and
 
 ## Determining Challenge Rating
 
-Many actions that you will undertake in *Open Legend* have a Challenge Rating (CR) that is determined by the rules. Attacks in combat, for example, use one of the target’s defense scores as the CR.
+Many actions that you will undertake in *Open Legend* have a Challenge Rating (CR) that is determined by the rules. Attacks in combat, for example, use one of the target's defense scores as the CR.
 
-Oftentimes, though, the GM will need to determine the CR for actions that aren’t spelled out clearly in the rules. In these cases, the GM can use the Challenge Ratings by Difficulty Table to set an appropriate CR.
+Oftentimes, though, the GM will need to determine the CR for actions that aren't spelled out clearly in the rules. In these cases, the GM can use the Challenge Ratings by Difficulty Table to set an appropriate CR.
 
 
 \NextTableColumns{OLT{.25}OCT{.25}OLT{.50}}
@@ -681,23 +681,23 @@ Oftentimes, though, the GM will need to determine the CR for actions that aren�
 
 | Difficulty | Challenge Rating | Example Actions |
 | :-: | :-: | :------ |
-| Everyday | 10 | leap a 5’ gap, climb a surface with ledges, break down a household door, haggle a simple merchant for a discount |
+| Everyday | 10 | leap a 5' gap, climb a surface with ledges, break down a household door, haggle a simple merchant for a discount |
 | Challenging | 15 | climb a rough surface, catch the drift of a text in an unfamiliar language, break down a strong wooden door |
-| Heroic | 20 | climb a smooth surface, leap a 15’ gap, translate a text in an unfamiliar language, convince a neutral party to take a risk for you |
+| Heroic | 20 | climb a smooth surface, leap a 15' gap, translate a text in an unfamiliar language, convince a neutral party to take a risk for you |
 | Epic | 25 | translate a text in an alien language, break down an iron door |
-| Legendary | 30 | leap a 25’ chasm, climb a flat surface, befriend an enemy with a vendetta against you |
+| Legendary | 30 | leap a 25' chasm, climb a flat surface, befriend an enemy with a vendetta against you |
 
-It’s important to note that Challenge Ratings are not typically set to be relative to the party’s level. So, breaking down a strong wooden door is CR 15 whether the party is first level or tenth.
+It's important to note that Challenge Ratings are not typically set to be relative to the party's level. So, breaking down a strong wooden door is CR 15 whether the party is first level or tenth.
 
 ### Contested Actions
 
 Sometimes, two or more characters are directly opposing each other in a test of strength, wits, or charm. For example, a mighty barbarian wrestles with a minotaur to get hold of a magical gem. Or three representatives of different star systems attempt to persuade the warleader of the intergalactic reavers to join their forces. Or a stealthy ninja attempts to sneak unseen past the watch of the monks on guard. These sorts of situations are called **contested actions**.
 
-To resolve such contests, each character involved makes an action roll using an appropriate attribute. Whoever rolls the highest succeeds at the action. Sometimes, all parties use the same attribute for their action rolls, but often, each character will use a different attribute, as in the case of the rogue attempting to sneak (Agility) past the guard’s watch (Perception).
+To resolve such contests, each character involved makes an action roll using an appropriate attribute. Whoever rolls the highest succeeds at the action. Sometimes, all parties use the same attribute for their action rolls, but often, each character will use a different attribute, as in the case of the rogue attempting to sneak (Agility) past the guard's watch (Perception).
 
 ## Advantage and Disadvantage
 
-Sometimes, you will attempt an action under circumstances that give you a significant upper hand, such as when attacking an enemy from behind. Other times, you’ll be working against exceptional hindrances, such as when trying to climb a rope that an enemy has covered in grease. In these types of cases, instead of adjusting the Challenge Rating of the task, the GM should assign your roll either **advantage** or **disadvantage**.
+Sometimes, you will attempt an action under circumstances that give you a significant upper hand, such as when attacking an enemy from behind. Other times, you'll be working against exceptional hindrances, such as when trying to climb a rope that an enemy has covered in grease. In these types of cases, instead of adjusting the Challenge Rating of the task, the GM should assign your roll either **advantage** or **disadvantage**.
 
 Advantage and disadvantage are always expressed with a numeric level, such as “advantage 1” or “disadvantage 3”. Multiple instances of advantage and disadvantage can add together, so if you have advantage 1 on an attack because you are flanking a foe, and you also possess a feat that grants you advantage 1, you have a total of advantage 2.
 
@@ -774,7 +774,7 @@ Before making an action roll, a PC may spend a maximum number of legend points e
 
 # Feats #
 
-In this chapter, you’ll find complete descriptions of all of the feats available to customize your character in Open Legend. Feats are used to define your character’s specializations, the actions, tasks, and abilities they excel at beyond all others. Some feats will enhance your major actions, such as by allowing you to multi-attack with reduced disadvantage, while others will grant you completely new powers, such as the ability to change your shape.
+In this chapter, you'll find complete descriptions of all of the feats available to customize your character in Open Legend. Feats are used to define your character's specializations, the actions, tasks, and abilities they excel at beyond all others. Some feats will enhance your major actions, such as by allowing you to multi-attack with reduced disadvantage, while others will grant you completely new powers, such as the ability to change your shape.
 
 ## Acquiring Feats
 
@@ -1468,7 +1468,7 @@ against magical curses such as lycanthropy.
 causes you to be resistant to that type of energy. \newline
 
 **Effect:** Choose from the following energy types: fire, cold, lightning, acid, (or
-another at the GM’s discretion). When you are attacked with that energy
+another at the GM's discretion). When you are attacked with that energy
 type, you gain resistance to the attack as follows:
 
 -   **Tier 1** - Your defense scores are increased by 3 against the chosen energy type.
@@ -1591,7 +1591,7 @@ the reduced speed typically incurred at the GM's discretion.
 -   **Tier 2:** Influence 5
 -   **Tier 3:** Influence 7
 
-**Description:** Creatures that you’ve magically compelled become even stronger when
+**Description:** Creatures that you've magically compelled become even stronger when
 fighting in your defense or under your command. \newline
 
 **Effect:** Creatures under the effects of your Charmed or Dominated bane gain
@@ -1723,7 +1723,7 @@ bane or boon:
     -   Attribute 8 = 10 miles
     -   Attribute 9 = 100 miles
 -   Negate two levels of disadvantage caused by multi-targeting (e.g., Target 2 creatures or a 10' square for free instead of disadvantage 2).
--   For your action roll, treat your attribute score as if it was one greater for purposes of determining attribute dice. Note that this doesn’t grant access to banes or boons you could not normally access. It only increases the dice used for the action roll.
+-   For your action roll, treat your attribute score as if it was one greater for purposes of determining attribute dice. Note that this doesn't grant access to banes or boons you could not normally access. It only increases the dice used for the action roll.
 
 **Tier 2** - You gain the following abilities:
 
@@ -1850,7 +1850,7 @@ ispired to fight beyond their usual mettle. \newline
 your general intelligence. \newline
 
 **Effect:** When you purchase this feat, choose a sphere of knowledge from the list
-below or, with the GM’s approval, create a new one.
+below or, with the GM's approval, create a new one.
 
 Example spheres of knowledge include alchemy, arcane, supernatural,
 engineering, geography, history, location (must specify), anatomy,
@@ -2233,7 +2233,7 @@ fox, or some similar exceptional non-combat talent. \newline
 
 **Effect:** Choose one attribute. Any time you make a non-attack action roll with the chosen attribute, you gain advantage 1 on the roll per tier of this feat you possess for that attribute. \newline
 
-**Special:** You can take this feat multiple times. Each time, you can either apply it to a different attribute or increase the feat tier for an attribute you’ve already purchased.
+**Special:** You can take this feat multiple times. Each time, you can either apply it to a different attribute or increase the feat tier for an attribute you've already purchased.
 
 
 ## Superior Concentration (I - III)
@@ -2323,7 +2323,7 @@ enthralled by you. \newline
 roll within 24 hours of being afflicted become permanently affected by
 the bane. They do not receive any more resist rolls to shake themselves
 free of the effect. Other extraordinary effects like a Nullify bane can
-still end the effect (and other methods may work at the GM’s
+still end the effect (and other methods may work at the GM's
 discretion).
 
 ## Untrackable
@@ -2400,7 +2400,7 @@ you're not specialized in. \newline
 
 # Wealth & Equipment #
 
-No story of heroic deeds is complete without equally heroic gear, weapons and armor. Indiana Jones had his whip, King Arthur had *Excalibur*, and Bilbo had his mithril shirt. In this chapter, you’ll learn everything you need to know about how to equip your character at first level and beyond, as well as how to keep track of your wealth as you capture dragon hoards and seize kingdoms.
+No story of heroic deeds is complete without equally heroic gear, weapons and armor. Indiana Jones had his whip, King Arthur had *Excalibur*, and Bilbo had his mithril shirt. In this chapter, you'll learn everything you need to know about how to equip your character at first level and beyond, as well as how to keep track of your wealth as you capture dragon hoards and seize kingdoms.
 
 ## Wealth
 Rather than tracking every gold piece, gem, and fine art object that you acquire over the course of your adventures, Open Legend uses a simplified wealth system.
@@ -2412,7 +2412,7 @@ When you are trying to buy new equipment, construct a building, or hire a crafts
 
 If the good you want to purchase has a level lower than your Wealth Score, you can acquire the item easily without taxing your time and resources.
 
-If the item’s level is **equal to** your Wealth Score, you can acquire it, but the expense taxes your resources such that you cannot acquire new goods at that level or higher for two weeks.
+If the item's level is **equal to** your Wealth Score, you can acquire it, but the expense taxes your resources such that you cannot acquire new goods at that level or higher for two weeks.
 
 If the object of your purchase is **one level higher than** your Wealth Score and your Wealth Score is above 0, you can acquire it, but the cost is so great that your Wealth Score is reduced by 1.
 
@@ -2439,13 +2439,13 @@ You cannot make purchases that are more than one level higher than your Wealth S
 | 8 | 10th level hero | startup funding for a new city, an army of 10,000 |
 | 9 | emperor | a castle, a space station, an army of 50,000, a fleet of warships |
 
-**The Rule of Common Sense**. Your Wealth Score determines which purchases are possible given the proper circumstances. Obviously, if you are in the middle of a desert, you can’t buy a keg of water even if you have the wealth of an emperor. Likewise, even though you have enough money to raise an army, the GM may rule that you still require the appropriate amount of time, effort, and charisma to convince the soldiers to follow you.
+**The Rule of Common Sense**. Your Wealth Score determines which purchases are possible given the proper circumstances. Obviously, if you are in the middle of a desert, you can't buy a keg of water even if you have the wealth of an emperor. Likewise, even though you have enough money to raise an army, the GM may rule that you still require the appropriate amount of time, effort, and charisma to convince the soldiers to follow you.
 
 ### Gaining Wealth
 
-As you travel the stars, slay mythic beasts, and win over affluent nobles, your wealth will increase. The GM decides when a character’s wealth increases, and the Wealth Overview table provides a few milestones of typical character Wealth Scores at different levels.
+As you travel the stars, slay mythic beasts, and win over affluent nobles, your wealth will increase. The GM decides when a character's wealth increases, and the Wealth Overview table provides a few milestones of typical character Wealth Scores at different levels.
 
-Typical situations of when the GM would grant you an increase in your Wealth Score include acquiring a large hoard from a monster’s lair, finding a buyer for an item of great power or value, or being rewarded by a great ruler.
+Typical situations of when the GM would grant you an increase in your Wealth Score include acquiring a large hoard from a monster's lair, finding a buyer for an item of great power or value, or being rewarded by a great ruler.
 
 ## Carrying Capacity
 
@@ -2453,17 +2453,17 @@ Typical situations of when the GM would grant you an increase in your Wealth Sco
 
 ### Twenty Items Max
 
-You can carry up to twenty pieces of gear. No more. Only track the items that will actually affect the game. So, no, you don’t need to record your pants and shirt on your character sheet. But, your armor does count.
+You can carry up to twenty pieces of gear. No more. Only track the items that will actually affect the game. So, no, you don't need to record your pants and shirt on your character sheet. But, your armor does count.
 
 Multiple items of a similar nature that can be stowed together, such as twenty arrows in a quiver or a belt of healing potions, only count as a single item. The GM can use their own discretion to apply common sense limits if necessary. For example, even though technically 1000 clips of ammo would count as a single item, the GM is free to rule that a PC can't carry them or that they would count as a *bulky* item (see below).
 
 ### Maximum *Heavy* Items Equals Might Score
 
-Some items have the *heavy* property. You can carry a number of *heavy* items equal to your Might score. Once you’re carrying your maximum number of *heavy* items, your speed is cut in half. A character with a zero Might score cannot carry any heavy items.
+Some items have the *heavy* property. You can carry a number of *heavy* items equal to your Might score. Once you're carrying your maximum number of *heavy* items, your speed is cut in half. A character with a zero Might score cannot carry any heavy items.
 
 ### One (Maybe Two) *Bulky* Items
 
-Some items have the *bulky* property. You can carry one *bulky* item at no penalty. You can carry a second *bulky* item, but your speed is reduced to 5’.
+Some items have the *bulky* property. You can carry one *bulky* item at no penalty. You can carry a second *bulky* item, but your speed is reduced to 5'.
 
 
 
@@ -2500,22 +2500,22 @@ In this section you will find the tools needed to pick weapons and armor that yo
 
 * **Melee** - weapons in this category are meant for close quarters hand-to-hand combat.
 
-    * **One-handed Melee** - The weapon uses a single hand and allows the other hand to be used for carrying another object, second weapon, or kept free for other actions. When wielding a one-handed weapon in each hand, you gain advantage 1 to all melee attacks; with two weapons, you have a better chance of capitalizing on openings in your target’s defense. If both weapons you are wielding have passive benefits such as the Deadly or Defensive properties, your benefit is the best of the two but does not stack.
+    * **One-handed Melee** - The weapon uses a single hand and allows the other hand to be used for carrying another object, second weapon, or kept free for other actions. When wielding a one-handed weapon in each hand, you gain advantage 1 to all melee attacks; with two weapons, you have a better chance of capitalizing on openings in your target's defense. If both weapons you are wielding have passive benefits such as the Deadly or Defensive properties, your benefit is the best of the two but does not stack.
     * **Two-Handed Melee** - The weapon requires two hands to wield and cannot be used with a shield or other weapon. Two-handed melee weapons grant advantage 1 to all attacks; blows delivered with both hands are usually more deadly.
     * **Versatile Melee** - The weapon can be wielded either one-handed or two-handed. The wielder can freely switch between the two modes and has all of the benefits and restrictions of whichever mode they are using.
 
 * **Ranged** - Weapons in this category can be used to make ranged attacks with no penalty up to their range increment (in feet). Attacks made up to twice the normal range suffer disadvantage 1, and attacks made up to three times the normal range suffer disadvantage 2. Attacks at farther distances cannot be made. Note that ammunition for ranged weapons is generally not kept track of, as it is assumed you have brought enough ammo with you. A weapon like a rocket launcher should be handled as one-time use, consumable extraordinary item.
     * **Range Increments**
 
-        * **Close Ranged** - Range increment of 25’.
-        * **Short Ranged** - Range increment of 50’.
-        * **Medium Ranged** - Range increment of 75’.
-        * **Long Ranged** - Range increment of 125’.
-        * **Extreme Ranged** - Range increment of 300’.
+        * **Close Ranged** - Range increment of 25'.
+        * **Short Ranged** - Range increment of 50'.
+        * **Medium Ranged** - Range increment of 75'.
+        * **Long Ranged** - Range increment of 125'.
+        * **Extreme Ranged** - Range increment of 300'.
 
     * **Close** and **Short** Ranged weapons are built to be compact and effective in close quarters, so they are less bulky. They can be wielded with a single hand, allowing the other hand to be used for carrying a shield, second weapon, or kept free for other actions.
     * **Medium**, **Long**, and **Extreme** Ranged weapons have various strengths, but are not built for close quarters combat. As such, they require two hands and cannot be used with any weapon or other item in the wielders off hand.
-    * **Extreme** Ranged weapons are built for distance and given their specialized calibration, cannot be used to attack a target closer than 50’.
+    * **Extreme** Ranged weapons are built for distance and given their specialized calibration, cannot be used to attack a target closer than 50'.
 
 **WL (Wealth Level)** is an indication of how expensive the item is to purchase. See the **Wealth** section earlier in this chapter for an explanation of how that works.
 
@@ -2581,11 +2581,11 @@ In this section you will find the tools needed to pick weapons and armor that yo
 
 **Precise** - This weapon can be used to make attacks with the Agility attribute  and invoke banes accessible via Agility.
 
-**Reach** - The weapon can be used to attack enemies 10’ away.
+**Reach** - The weapon can be used to attack enemies 10' away.
 
 **Slow** - If you are wielding this weapon at the beginning of combat, you gain disadvantage 2 on your initiative roll. If you are not wielding the weapon but plan to use it on your first turn, this penalty is applied. If you are wielding multiple weapons, your initiative modifier is equal to the slowest among them (slow, swift, or neither).
 
-**Stationary** - the bulk and weight of this weapon is enormous. Moving it requires a Focus Action from an assisting character which transports the weapon 30’.
+**Stationary** - the bulk and weight of this weapon is enormous. Moving it requires a Focus Action from an assisting character which transports the weapon 30'.
 
 **Swift** - If you are wielding this weapon at the beginning of combat, you gain advantage 2 on your initiative roll. If you are not wielding the weapon but plan to use it on your first turn, you get this bonus. If you are wielding multiple weapons, your initiative modifier is equal to the slowest among them (slow, swift, or neither).
 
@@ -2606,7 +2606,7 @@ The Armor table summarizes the following properties of each type of armor:
 
 **Speed Penalty** indicates the reduction in speed that your character suffers due to the bulkiness and weight of the armor.
 
-Donning and removing armor takes 1 round for light armor, 1 minute for medium armor, and 10 minutes for heavy armor. Sleeping in medium or heavy armor is only possible with special training. Without the Armor Mastery feat, sleeping in armor causes your character to gain one level of the Fatigued bane, which applies disadvantage 1 to all action rolls until they get a proper night’s rest.
+Donning and removing armor takes 1 round for light armor, 1 minute for medium armor, and 10 minutes for heavy armor. Sleeping in medium or heavy armor is only possible with special training. Without the Armor Mastery feat, sleeping in armor causes your character to gain one level of the Fatigued bane, which applies disadvantage 1 to all action rolls until they get a proper night's rest.
 
 \NextTableColumns{OLT{.25}OCT{.15}OCT{.15}OCT{.15}OCT{.15}OCT{.15}}
 
@@ -2617,18 +2617,18 @@ Donning and removing armor takes 1 round for light armor, 1 minute for medium ar
 | Leather Armor, Padding, Steelsilk | Light | 1 | 0 | 1 | 0 |
 | Kevlar Vest, Bioweave | Medium | 2 | 2 | 2 | 0 |
 | Chain Shirt, Full Body Armor | Medium | 2 | 3 | 2 | 0 |
-| Yoroi Armor, Plate Mail | Heavy | 2 | 3 | 3 | 5’ |
+| Yoroi Armor, Plate Mail | Heavy | 2 | 3 | 3 | 5' |
 | Power Armor, Elven Plate Mail | Heavy | 4 | 1 | 3 | 0 |
 
 
 
 ## Building Your Own Weapons
 
-Open Legend is all about freeform creativity, so we’ve given you lots of examples with the Weapons table, but the list is by no means exhaustive. If you want to build your own custom weapon, follow the steps below
+Open Legend is all about freeform creativity, so we've given you lots of examples with the Weapons table, but the list is by no means exhaustive. If you want to build your own custom weapon, follow the steps below
 
 ### Step 1: Choose a Category
 
-Typically a weapon belongs to one category, however some weapons, such as a dagger or a hybrid sword-gun might fall into two categories. No weapon should fall into more than two categories, but selecting either one or two categories is at the discretion of the player and GM. This step has no impact on the weapon’s cost.
+Typically a weapon belongs to one category, however some weapons, such as a dagger or a hybrid sword-gun might fall into two categories. No weapon should fall into more than two categories, but selecting either one or two categories is at the discretion of the player and GM. This step has no impact on the weapon's cost.
 
 ### Step 2: Choose Properties
 
@@ -2636,7 +2636,7 @@ Every weapon must have either the *Forceful* or *Precise* property and some weap
 
 Next, you will may select a number of properties that have significant game impact, just like *Forceful* and *Precise*, these are listed under properties. The difference is that these other properties each have the effect of raising the Wealth Level of the weapon. The Wealth Level of all weapons begins at 1.
 
-The *Deadly* property increases an item’s Wealth Level by 2 per tier. So a *Deadly 2* item has a starting Wealth Level of 5.
+The *Deadly* property increases an item's Wealth Level by 2 per tier. So a *Deadly 2* item has a starting Wealth Level of 5.
 
 The *Defensive* property increases the Wealth Level of the item by 1 per tier, so *Defensive 3* would increase the item's Wealth Level by 3.
 
@@ -2673,13 +2673,13 @@ Let's build our own weapon as an example. The kusaria-gama is a very unique weap
 
 ## Mounts & Vehicles
 
-In this section, you’ll find rules for mounting upon your battle-bred warhorse or piloting your trusty old fighter ship. For mechanical purposes, mounts and vehicles are handled the same. These rules will apply whenever a character is riding upon or within another creature or object as their primary form of movement. You will move with your mount (see mount actions below), but otherwise you are considered separate for purposes of targeting, boons, banes, and similar situations.
+In this section, you'll find rules for mounting upon your battle-bred warhorse or piloting your trusty old fighter ship. For mechanical purposes, mounts and vehicles are handled the same. These rules will apply whenever a character is riding upon or within another creature or object as their primary form of movement. You will move with your mount (see mount actions below), but otherwise you are considered separate for purposes of targeting, boons, banes, and similar situations.
 
 Throughout this text, the words “mount” and “vehicle” are used interchangeably. Mechanically speaking, the rules are the same whether you are riding a pony or a star fighter, so any references to “mount” also apply to “vehicles”, and vice-versa.
 
 ### Mount Actions
 
-When mounted, you may allocate any of your actions to your mount instead of yourself. For example, while riding a velociraptor, you could spend your move action to have your raptor move 40’. Whenever your mount moves, you move with it. Likewise, instead of attacking with your own weapons, you could spend your major action to let your raptor make an attack. Your mount will have its own attributes and feats, so it will not benefit from your feats or attributes.
+When mounted, you may allocate any of your actions to your mount instead of yourself. For example, while riding a velociraptor, you could spend your move action to have your raptor move 40'. Whenever your mount moves, you move with it. Likewise, instead of attacking with your own weapons, you could spend your major action to let your raptor make an attack. Your mount will have its own attributes and feats, so it will not benefit from your feats or attributes.
 
 Typically, mounts and vehicles cannot act independently of their riders, and so they will only get to take actions when their rider allocates actions to them.
 
@@ -2696,13 +2696,13 @@ Detailed below are a variety of mounts and vehicles for characters to carry char
 
 **Properties** are the descriptors that make each mount unique from others. These properties translate to specific game mechanics described below.
 
-**Attributes** indicates the notable attributes possessed by the vehicle or mount. At the GM’s discretion, other attributes can be granted on an as-needed basis.
+**Attributes** indicates the notable attributes possessed by the vehicle or mount. At the GM's discretion, other attributes can be granted on an as-needed basis.
 
 **Feats** indicates the feats which the mount or vehicle possesses to highlight its unique capabilities. These feats only apply to actions taken by the mount, not actions made by the rider.
 
 **HP (Hit Points)** indicates the total hit points possessed by the vehicle or mount.
 
-**DT (Damage Threshold)** is an indication of how much punishment the mount or vehicle can take. When a vehicle reaches zero hit points, it gains one damage level and its hit points return to maximum. Any remaining damage is carried over to the it’s new hit point total, thus a vehicle can suffer multiple damage levels from a single attack if it deals enough damage. A mount has disadvantage equal to its damage level on all action rolls. Once the mount’s damage level reaches its damage threshold, it is disabled (unable to act) until healed or repaired. Repairing or healing one damage level requires 1 day per wealth level of the vehicle.
+**DT (Damage Threshold)** is an indication of how much punishment the mount or vehicle can take. When a vehicle reaches zero hit points, it gains one damage level and its hit points return to maximum. Any remaining damage is carried over to the it's new hit point total, thus a vehicle can suffer multiple damage levels from a single attack if it deals enough damage. A mount has disadvantage equal to its damage level on all action rolls. Once the mount's damage level reaches its damage threshold, it is disabled (unable to act) until healed or repaired. Repairing or healing one damage level requires 1 day per wealth level of the vehicle.
 
 **Defenses** are the Toughness, Guard, and Resolve defenses of the vehicle or mount. If "Immune" is listed for a given defense, then attacks targeting that defense have no effect.
 
@@ -2711,7 +2711,7 @@ Detailed below are a variety of mounts and vehicles for characters to carry char
 
 **Faster than Light** - The vehicle is capable of traveling faster than the speed of light. Doing so requires that a pilot expend a focus action on three consecutive rounds.
 
-**Guided Weapons** - Attacks made with this vehicle are particularly difficult to evade. When the vehicle makes an attack using an attribute greater than zero, it rolls an additional d20 and keeps the higher die. This benefit only applies to attacks that target an opponent’s Guard defense.
+**Guided Weapons** - Attacks made with this vehicle are particularly difficult to evade. When the vehicle makes an attack using an attribute greater than zero, it rolls an additional d20 and keeps the higher die. This benefit only applies to attacks that target an opponent's Guard defense.
 
 **Multi-Pilot** - The vehicle can be piloted by a number of people equal to the value indicated. Each pilot can make use of the vehicle to make actions, but no more than 2 move actions can be taken by the vehicle in each round.
 
@@ -2726,46 +2726,46 @@ Detailed below are a variety of mounts and vehicles for characters to carry char
 
 | Examples | WL | TL | Speed | Properties | Attributes | Feats | HP | DT | Defenses |
 | :----- | :-: | :-: | :-: | :-----: | :----: | :-----: | :-: | :-: | :-------- |
-| All-Terrain Jeep | 2 | 1 | 80’ | | Agility 4 | | 20 | 2 | Toughness: 14 \
+| All-Terrain Jeep | 2 | 1 | 80' | | Agility 4 | | 20 | 2 | Toughness: 14 \
 Guard: 14 \
 Resolve: Immune |
-| Battle Cruiser | 9 | 3 | 1,000’ | Faster than Light, Guided Weapons, Targeted Weapons, Independent 2, Multi-Pilot 4 | Energy 7 | Multi-Target Attack Specialist (Area) 5 | 50 | 5 | Toughness: 18 \
+| Battle Cruiser | 9 | 3 | 1,000' | Faster than Light, Guided Weapons, Targeted Weapons, Independent 2, Multi-Pilot 4 | Energy 7 | Multi-Target Attack Specialist (Area) 5 | 50 | 5 | Toughness: 18 \
 Guard: 25 \
 Resolve: Immune |
-| Drake | 5 | 0 | 50’ | Independent 1 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 38 | 1 | Toughness: 18 \
+| Drake | 5 | 0 | 50' | Independent 1 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 38 | 1 | Toughness: 18 \
 Guard: 20 \
 Resolve: 15 |
-| Fighter Ship | 5 | 3 | 2,000’ | Faster than Light, Guided Weapons, Targeted Weapons, Multi-Pilot 2 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 36 | 4 | Toughness: 15 \
+| Fighter Ship | 5 | 3 | 2,000' | Faster than Light, Guided Weapons, Targeted Weapons, Multi-Pilot 2 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 36 | 4 | Toughness: 15 \
 Guard: 22 \
 Resolve: Immune |
-| Galleon | 6 | 0 | 70’ | Targeted Weapons, Multi-Pilot 10 | Agility 6 | Multi-Target Attack Specialist (Area) 3 | 30 | 5 | Toughness: 15 \
+| Galleon | 6 | 0 | 70' | Targeted Weapons, Multi-Pilot 10 | Agility 6 | Multi-Target Attack Specialist (Area) 3 | 30 | 5 | Toughness: 15 \
 Guard: 19 \
 Resolve: Immune |
-| Griffin | 4 | 0 | 50’ | Independent 1 | Might 5 | Bane Focus (Immobile) | 34 | 1 | Toughness: 16 \
+| Griffin | 4 | 0 | 50' | Independent 1 | Might 5 | Bane Focus (Immobile) | 34 | 1 | Toughness: 16 \
 Guard: 19 \
 Resolve: 13 |
-| Horse | 3 | 0 | 40’ | | Might 4 | | 28 | 1 | Toughness: 15 \
+| Horse | 3 | 0 | 40' | | Might 4 | | 28 | 1 | Toughness: 15 \
 Guard: 15 \
 Resolve: 10 |
-| Mech Unit | 4 | 2 | 40’ | Guided Weapons, Targeted Weapons | Energy 5 \
+| Mech Unit | 4 | 2 | 40' | Guided Weapons, Targeted Weapons | Energy 5 \
 Agility 6 | Multi-Target Attack Specialist (Area) 2 | 22 | 3 | Toughness: 20 \
 Guard: 22 \
 Resolve: Immune |
-| Phoenix | 5 | 0 | 50’ | | Energy 7 | Attack Specialization II (Fire) | 32 | 1 | Toughness: 16 \
+| Phoenix | 5 | 0 | 50' | | Energy 7 | Attack Specialization II (Fire) | 32 | 1 | Toughness: 16 \
 Guard: 20 \
 Resolve: 19 |
-| Pegasus | 4 | 0 | 50’ | | Might 4 \
+| Pegasus | 4 | 0 | 50' | | Might 4 \
 Creation 4 | Boon Focus I (Heal) | 28 | 1 | Toughness: 17 \
 Guard: 18 \
 Resolve: 17 |
-| Velociraptor, Dire Wolf | 3 | 0 | 40’ | | Agility 5 \
+| Velociraptor, Dire Wolf | 3 | 0 | 40' | | Agility 5 \
 Perception 5 | Bane Focus I (Knockdown) | 24 | 1 | Toughness: 14 \
 Guard: 17 \
 Resolve: 15 |
-| T-Rex | 5 | 0 | 50’ | Independent 1 | Might 6 | Attack Specialization II (Bite) | 38 | 1 | Toughness: 15 \
+| T-Rex | 5 | 0 | 50' | Independent 1 | Might 6 | Attack Specialization II (Bite) | 38 | 1 | Toughness: 15 \
 Guard: 20 \
 Resolve: 15 |
-| Giant Scorpion | 4 | 0 | 35’ | Independent 1 | Agility 5 \
+| Giant Scorpion | 4 | 0 | 35' | Independent 1 | Agility 5 \
 Perception 5 | Bane Focus I (Persistent Damage) | 20 | 2 |  Toughness: 15 \
 Guard: 15 \
 Resolve: 18 |
@@ -2775,7 +2775,7 @@ Resolve: 18 |
 
 Banes and boons are a huge part of what makes *Open Legend* so open. They represent the endless possibilities of effects that your character can have on other characters beyond simply dealing damage. Banes are negative conditions that you inflict upon your foes, such as by stunning them, demoralizing them, or setting them on fire. Boons are the opposite: helpful effects that assist your allies by allowing them to fly, shrug off damage, or move with extraordinary speed.
 
-Banes and boons are not tied to specific spells, attacks, or items. Any character can invoke any bane or boon as long as the character possesses the prerequisite attributes. Attribute prerequisites are meant to limit the power of banes and boons so that they scale as your character gains power. That is why, for example, your first level necromancer can invoke the *Blindsight* boon with their Entropy attribute of 5, but won’t be able to invoke the *Insubstantial* boon for themself or their allies until they gain enough experience to increase their Entropy to 7.
+Banes and boons are not tied to specific spells, attacks, or items. Any character can invoke any bane or boon as long as the character possesses the prerequisite attributes. Attribute prerequisites are meant to limit the power of banes and boons so that they scale as your character gains power. That is why, for example, your first level necromancer can invoke the *Blindsight* boon with their Entropy attribute of 5, but won't be able to invoke the *Insubstantial* boon for themself or their allies until they gain enough experience to increase their Entropy to 7.
 
 A list of available banes and boons can be found in this SRD under the [banes section](#banes-list) and [boons section](#boons-list) and a searchable and filterable list of available banes and boons can be found on the [Open Legend Website](http://www.openlegendrpg.com/), respectively.
 
@@ -2791,9 +2791,9 @@ In *Open Legend*, we use the rules to make sure the game is fair and that everyo
 
 ## Invoking Banes and Boons
 
-To invoke a bane, the primary method is to succeed at an appropriate attribute roll using one of your target’s defense scores as the Challenge Rating, as indicated in the bane description. An alternate method of invoking a bane is to make a successful damaging attack that exceeds the target's defense by 10 or more. When this happens, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target. While targets may be effected by multiple banes, you may not *stack* banes; A target cannot be inflicted with a bane it is currently suffering from, unless specified in the bane's effect (*e.g.* *Fatigued*).
+To invoke a bane, the primary method is to succeed at an appropriate attribute roll using one of your target's defense scores as the Challenge Rating, as indicated in the bane description. An alternate method of invoking a bane is to make a successful damaging attack that exceeds the target's defense by 10 or more. When this happens, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target. While targets may be effected by multiple banes, you may not *stack* banes; A target cannot be inflicted with a bane it is currently suffering from, unless specified in the bane's effect (*e.g.* *Fatigued*).
 
-To invoke a boon, you must succeed at an appropriate attribute roll with a Challenge Rating determined by the boon’s Power Level. The CR equals 10 + 2 x Power Level. If a boon can be invoked at multiple Power Levels, you decide which Power Level to invoke at after making your action roll. While targets may be effected by different boons, you may not *stack* the same boon multiple times; if a second invocation of a boon would be applied to a character, they choose which boon to keep and which one to negate.
+To invoke a boon, you must succeed at an appropriate attribute roll with a Challenge Rating determined by the boon's Power Level. The CR equals 10 + 2 x Power Level. If a boon can be invoked at multiple Power Levels, you decide which Power Level to invoke at after making your action roll. While targets may be effected by different boons, you may not *stack* the same boon multiple times; if a second invocation of a boon would be applied to a character, they choose which boon to keep and which one to negate.
 
 Additional details about invoking banes and boons, such as attack range and targeting multiple creatures, can be found in Chapter 6: Combat.
 
@@ -2805,7 +2805,7 @@ Each bane description includes the following elements.
 
 **Attack Attributes.** This is a list of the attribute or attributes that can be used to inflict the bane. As long as you possess at least one of the listed attributes at a score greater than or equal to the Power Level, then you can inflict the bane.
 
-**Attack.** This list indicates what type of attack roll to make when inflicting the bane. Each entry consists of an attribute that the attacking player should roll and the defense score targeted by the attack. If the attacker’s roll equals or exceeds the target’s defense score, then the bane is inflicted.
+**Attack.** This list indicates what type of attack roll to make when inflicting the bane. Each entry consists of an attribute that the attacking player should roll and the defense score targeted by the attack. If the attacker's roll equals or exceeds the target's defense score, then the bane is inflicted.
 
 **Duration.** A bane typically remains in effect until the target resists it with a *Resist* roll, hence most banes have a duration of “resist ends”. If a target fails three resist rolls against a bane, the bane can no longer be resisted. It persists for an extended duration indicated in parentheses.
 
@@ -2893,7 +2893,7 @@ on the power level of the bane when invoked.
 this bane prevents the target from being aware of their affliction and
 thus prevents them from actively attempting to break free. However, the
 targets true mind is magically suppressed but fights to regain control.
-As such, at the end of each of it’s turns, the target receives a Resist
+As such, at the end of each of it's turns, the target receives a Resist
 roll as a free action to break free from the effect. When your target
 succeeds at a resist roll against this bane, they become to immune to
 all subsequent attempts by you to inflict the bane for the next 24
@@ -2934,7 +2934,7 @@ disadvantage 3.
 -   Entropy vs. Toughness
 
 **Description:** Utilizing either incredible precision or the power of entropy, the
-target’s life force is snuffed out completely. The most deadly assassins
+target's life force is snuffed out completely. The most deadly assassins
 and most powerful necromancers are known for such legendary skill at
 snuffing out life. \newline
 
@@ -2943,7 +2943,7 @@ is a brief window of time in which the target can attempt to resist this
 extinguishing force, but once that window closes, the death is permanent and can
 only be reversed if the GM allows a special mission to use rare technology or
 long-forgotten magic to restore the target. When the bane is initially applied,
-the target is immobile (can’t move from their current space) and unconscious.
+the target is immobile (can't move from their current space) and unconscious.
 They have disadvantage 5 on all perception rolls, and are incapable of moving.
 As a result of being completely incapable of movement, an incapacitated character
 can be the victim of a finishing blow. \newline
@@ -2952,7 +2952,7 @@ can be the victim of a finishing blow. \newline
 this bane prevents the target from being aware of their affliction and
 thus prevents them from actively attempting to break free. However, the
 targets body fights to regain consciousness and resist the pending
-death. As such, at the end of each of it’s turns, the target receives a
+death. As such, at the end of each of it's turns, the target receives a
 Resist roll as a free action to break free from the effect. Whereas 3
 failed resist rolls would usually persist the effects of the bane, this
 bane extinguishes the life force of the target on 3 failed saves, thus
@@ -3016,7 +3016,7 @@ of an object they are holding. \newline
 
 **Effect:**
 
--   **Power Level 3** - You force another character to drop an object they are holding. Choose a location within 15’ of the target, the item ends up there.
+-   **Power Level 3** - You force another character to drop an object they are holding. Choose a location within 15' of the target, the item ends up there.
 
 -   **Power Level 6** - As an alternative to moving the item, you can choose to assume control of it. If you do, you are now the wielder. For the wielder to regain control, they can react with a Disarmed bane of their own to counter the effect or make an attribute (typically Might) roll with a Challenge Rating equal to 10 + 2 x the attribute score you used to disarm the item.
 
@@ -3051,7 +3051,7 @@ cannot take action of any kind (except thought) unless it is ordered by
 you. Every action which the attacker orders the afflicted character to
 perform which is in extreme violation of their nature gives the target a
 Resist roll as a free action to break free from the effect. The attacker
-does not gain special access to the target’s mind and so can only order
+does not gain special access to the target's mind and so can only order
 the character to perform actions that they think or know (from prior
 knowledge) that the character is capable of. Lastly, each mental order that the attacker
 gives to the target is a major action, however the
@@ -3234,11 +3234,11 @@ immediately ends the bane). \newline
 **Description:** Incapacitation is a catch-all for a variety of effects, including total
 paralysis, sleep, petrification, poisoning, being knocked out, or
 fainting. Examples of possible causes of this bane include a martial
-artist’s paralyzing strike, an enchanter's magical song of sleep,
+artist's paralyzing strike, an enchanter's magical song of sleep,
 paralysis by poison, fainting from extreme heat, suffocation, and the
 gaze of a medusa. \newline
 
-**Effect:** The target is immobile (can’t move from their current space) and
+**Effect:** The target is immobile (can't move from their current space) and
 unconscious. They have disadvantage 5 on all perception rolls and are
 incapable of moving. As a result of being completely incapable of
 movement, an incapacitated character can be the victim of a finishing
@@ -3248,7 +3248,7 @@ blow.
 
 -   **Power Level 7** - The effect can only be broken if the target takes 1 point of damage.
 
--   **Power Level 9** - The effect cannot be disrupted by external forces, only the afflicted character’s successful resist roll can end the effect.
+-   **Power Level 9** - The effect cannot be disrupted by external forces, only the afflicted character's successful resist roll can end the effect.
 
 
 **Special:** While most banes last until the target actively attempts to resist it,
@@ -3304,7 +3304,7 @@ knowledge, prescience, or other means.
 
 -   **Power Level 5** - You temporarily modify a minor aspect of the target's memory. The target automatically regains the lost memory and realizes their confusion 1 hour later.
 
--   **Power Level 6** - You permanently erase or alter the last 5 minutes of the target’s memory. The target does not know what happened during this time outside of the memories you feed them (including having seen you, if they did). Multiple uses of this bane progressively erase consecutive 5 minute increments.
+-   **Power Level 6** - You permanently erase or alter the last 5 minutes of the target's memory. The target does not know what happened during this time outside of the memories you feed them (including having seen you, if they did). Multiple uses of this bane progressively erase consecutive 5 minute increments.
 
 -   **Power Level 8** - Instead of the immediate past, you can erase or alter memories from any time.
 
@@ -3329,15 +3329,15 @@ attempts of this bane from you for the next 24 hours.
 into the minds of others. \newline
 
 **Effect:**
--   **Power Level 2** - This power may only target creatures of animal intelligence or lower. You gain access to the target’s current thoughts.
+-   **Power Level 2** - This power may only target creatures of animal intelligence or lower. You gain access to the target's current thoughts.
 
--   **Power Level 4** - This power may target creatures of any intelligence. You gain access to the target’s current thoughts.
+-   **Power Level 4** - This power may target creatures of any intelligence. You gain access to the target's current thoughts.
 
--   **Power Level 6** - This power may target creatures of any intelligence. You gain access to the target’s current thoughts as well as its recent memories. Initially, you may probe 1 day into the past. For every round that the bane persists, you gain access access to an additional day’s worth of memories.
+-   **Power Level 6** - This power may target creatures of any intelligence. You gain access to the target's current thoughts as well as its recent memories. Initially, you may probe 1 day into the past. For every round that the bane persists, you gain access access to an additional day's worth of memories.
 
--   **Power Level 8** - This power may target creatures of any intelligence. You gain access to the target’s current thoughts as well as its distant memories. Initially, you may probe 1 year into the past. For every round that the bane persists, you gain access access to an additional year’s worth of memories. Alternatively, you may choose to gain the memories associated with a particular place, object, or event.
+-   **Power Level 8** - This power may target creatures of any intelligence. You gain access to the target's current thoughts as well as its distant memories. Initially, you may probe 1 year into the past. For every round that the bane persists, you gain access access to an additional year's worth of memories. Alternatively, you may choose to gain the memories associated with a particular place, object, or event.
 
--   **Power Level 9** - This power may target creatures of any intelligence. You gain access to the target’s current thoughts as well as all of its memories, without limitation by time. Alternatively, you may choose to gain the memories associated with a particular place, object, or event.
+-   **Power Level 9** - This power may target creatures of any intelligence. You gain access to the target's current thoughts as well as all of its memories, without limitation by time. Alternatively, you may choose to gain the memories associated with a particular place, object, or event.
 
 
 **Special:** When your target succeeds at a resist roll against this bane, they
@@ -3363,7 +3363,7 @@ for the next 24 hours.
 
 -   **Power Level 1** - You can cancel boons that must be actively invoked. In addition, the target cannot invoke that boon again for 1 minute.
 
--   **Power Level 6** - You can cancel boons that are permanent, passive, or inherent to the target (e.g. the invisibility of a Will o’ Wisp). In the absence of other rules, assume that the target can re-activate the boon as a major action.
+-   **Power Level 6** - You can cancel boons that are permanent, passive, or inherent to the target (e.g. the invisibility of a Will o' Wisp). In the absence of other rules, assume that the target can re-activate the boon as a major action.
 
 
 ## Persistent Damage
@@ -3386,7 +3386,7 @@ lasting and recurring source of damage. \newline
 
 **Effect:** At the beginning of the target's turn, before they take any actions, the
 target suffers damage determined by the power level of the bane. This
-damage automatically bypasses the afflicted character’s defenses but it
+damage automatically bypasses the afflicted character's defenses but it
 can be reduced by any resistance to damage of a certain type (see the
 Resistance boon). Like all dice rolls, these dice explode.
 
@@ -3622,7 +3622,7 @@ around the target, or from a physical effect like strangulation or suffocation.
 
 **Effect:** If Might, Agility, or Entropy is used to inflict this bane, then the
 character is suffering strangulation and unable to speak. If the bane is
-inflicted using Alteration, then all sound within 5’ of the target is
+inflicted using Alteration, then all sound within 5' of the target is
 magically suppressed, making their footsteps and the usual clank of
 belongings they are carrying inaudible.
 
@@ -3644,7 +3644,7 @@ belongings they are carrying inaudible.
 
 **Description:** The target's movement is impaired, either by extreme cold, prolonged heat, poison, or injury to one or both legs. \newline
 
-**Effect:** The afflicted target’s speed is reduced to half it's current speed, rounded down to the nearest 5' increment. This applies to
+**Effect:** The afflicted target's speed is reduced to half it's current speed, rounded down to the nearest 5' increment. This applies to
 all movement that is physical (flight, walking, climbing, etc.). If the
 target is currently under a magical effect that increases speed, the two
 effects are canceled for the duration that both affect the target.
@@ -3684,13 +3684,13 @@ that disorients the target. \newline
 
 -   Influence vs. Resolve
 
-**Description:** The stupefied bane has examples in many stories and legends: a vampire’s
+**Description:** The stupefied bane has examples in many stories and legends: a vampire's
 eyes, a siren's song, and a nymph's beauty are all known to cast a
 stupor upon weak-willed mortals. Being stupefied causes the character to
 be lulled into a false sense of security, tranquility, and pacifism. \newline
 
 **Effect:** The target is in a state of mental fog, lowering their mental defenses.
-While stupefied, the character’s Resolve defense is reduced to 10. In
+While stupefied, the character's Resolve defense is reduced to 10. In
 addition, the character has the approximate intelligence of a child. If
 attacked, it will defend itself until the attack ceases using its
 natural weapons, but the target will never employ any kind of complex
@@ -3707,7 +3707,7 @@ target an additional Resist roll to break free from the bane. Also any
 action that would startle a wild animal (hit with a rock, slap on the
 face, etc.) will also trigger a free Resist roll for the target. Unlike
 other resist rolls, those triggered by damage, fear, and trauma do not
-count against the target’s typically allowed failures of 3, beyond which
+count against the target's typically allowed failures of 3, beyond which
 the duration of the bane would extend. When your target succeeds at a
 resist roll against this bane, they become to immune to all subsequent
 attempts by you to inflict the bane for the next 24 hours.
@@ -3791,7 +3791,7 @@ Each boon description includes the following elements.
 
 **Invocation Time.** The required time that it takes to invoke the boon. Most boons have an invocation time of 1 major action. For boons that have a longer time, you must spend the entire invocation time concentrating on nothing other than invoking the boon. If you are interrupted, you must start the casting over.
 
-**Duration.** Most boons have a duration of “sustain persists”, which indicates that the invoker must use a sustain action every round in order to keep the boon in effect. If you have a boon in effect and don’t sustain it, the boon's effects cease at the end of your turn. Because sustaining a boon is a minor action, which can only be taken once per turn, you can typically sustain only one boon at a time.
+**Duration.** Most boons have a duration of “sustain persists”, which indicates that the invoker must use a sustain action every round in order to keep the boon in effect. If you have a boon in effect and don't sustain it, the boon's effects cease at the end of your turn. Because sustaining a boon is a minor action, which can only be taken once per turn, you can typically sustain only one boon at a time.
 
 **Description.** This entry simply provides a general idea of what the boon could look like in the story.
 
@@ -3860,7 +3860,7 @@ abilities of this animated creature and it should follow the guidelines
 established by the "Simple Build" section for creating NPCs / monsters in
 Chapter 7: Running the Game.
 
--   **Power Level 6** - You can animate a single creature. Your attribute score must be equal to or greater than the highest attribute score of the creature you’re animating. With a successful invocation, the creature comes into existence with the **Charmed** (Minor Charm) bane already in effect (no roll is required).
+-   **Power Level 6** - You can animate a single creature. Your attribute score must be equal to or greater than the highest attribute score of the creature you're animating. With a successful invocation, the creature comes into existence with the **Charmed** (Minor Charm) bane already in effect (no roll is required).
 
 -   **Power Level 8** - You can animate a group of creatures: Either 10 creatures with a max attribute of 2, or 5 creatures with a max attribute of 3, or 2 creatures with a max attribute of 5. In addition, the automatically invoked **Charmed** bane is a Major Charm instead of Minor Charm.
 
@@ -4033,9 +4033,9 @@ progressively improving speed and agility. \newline
 
 **Effect:**
 
--   **Power Level 5** - The target gains a flight speed of 10’ with low maneuverability.
+-   **Power Level 5** - The target gains a flight speed of 10' with low maneuverability.
 
--   **Power Level 6** - The target gains a flight speed of 30’ and is highly maneuverable.
+-   **Power Level 6** - The target gains a flight speed of 30' and is highly maneuverable.
 
 -   **Power Level 8** - The granted flight speed increases to 60'.
 
@@ -4506,7 +4506,7 @@ other similar means. \newline
 **Effect:**
 -   **Power Level 3** - You can teleport your target to any unoccupied space within 5 feet per Movement attribute score as long as you can naturally see it.
 
--   **Power Level 5** - Your teleportation range is unchanged, but you can now teleport your target to spaces that you can’t see. If you choose an occupied space, your target lands in the nearest adjacent space (roll randomly to decide if there are multiple options) and your target is stunned for 1 round (a resist roll is not needed to end the effect).
+-   **Power Level 5** - Your teleportation range is unchanged, but you can now teleport your target to spaces that you can't see. If you choose an occupied space, your target lands in the nearest adjacent space (roll randomly to decide if there are multiple options) and your target is stunned for 1 round (a resist roll is not needed to end the effect).
 
 -   **Power Level 7** - You can opt to take longer in invoking the boon. If you choose to, for each minute of invocation (delay before making your action roll) you can teleport the target 1 mile, up to a maximum number of miles equal to your Movement attribute score. While the distance is greater, this mode is also dangerous, as a misunderstanding of direction or geography can put your target many miles in an unfavorable direction. You simply choose a direction (relative to your starting location) and teleport your target a number of miles equal to your Movement score. During invocation, you must spend a Focus action each turn until the invocation time passes.
 
@@ -4615,13 +4615,13 @@ When the GM declares that combat will begin, the game is separated into rounds. 
 
 ### Determining Surprise
 
-In any combat, one or more combatants may be surprised if their enemy catches them off guard or unaware. For example, if a pack of bandits lays an ambush for the PCs in a rocky chasm, the GM may have every member of the party make a Perception roll contested by the bandits’ Agility roll. Any PC who fails the check is surprised. The GM decides when some or all combatants may be surprised.
+In any combat, one or more combatants may be surprised if their enemy catches them off guard or unaware. For example, if a pack of bandits lays an ambush for the PCs in a rocky chasm, the GM may have every member of the party make a Perception roll contested by the bandits' Agility roll. Any PC who fails the check is surprised. The GM decides when some or all combatants may be surprised.
 
 Surprised characters always act after non-surprised characters, as explained in the rules for initiative. Furthermore, until a surprised character takes their first turn, they may not take any interrupt actions and all attacks made against them gain advantage 1.
 
 ### Roll for Initiative
 
-After surprise has been determined, each combatant makes an Agility action roll. The total of a combatant’s Agility roll is their initiative score. The GM may decide to make one roll for each group of monsters instead of tracking every monster’s initiative individually.
+After surprise has been determined, each combatant makes an Agility action roll. The total of a combatant's Agility roll is their initiative score. The GM may decide to make one roll for each group of monsters instead of tracking every monster's initiative individually.
 
 Write down all initiative scores from highest to lowest. When taking turns in combat, characters act in order from highest initiative score to lowest. In case of ties, characters act in order of their Agility scores (from high to low). If Agility scores are also tied, determine order randomly.
 
@@ -4658,9 +4658,9 @@ Some GMs might love that kind of challenge, and for them, **the core mechanic ca
 | is less than the Challenge Rating, | The GM and the PC both choose 1: \
 Deal 3 damage \
 Inflict 1 bane of Power Level <= 3 \
-Move 10’ w/o opportunity attacks |
+Move 10' w/o opportunity attacks |
 
-With these modified rules, a player’s failed attack roll means that the player may not get what they were aiming for, but they get something. And it comes at a cost because the GM also gets to choose an effect. Remember, also, that the rules for interpreting a failed roll only apply to PCs. For the GM, a success is a success and a failure is a failure (See chapter 2 for more details).
+With these modified rules, a player's failed attack roll means that the player may not get what they were aiming for, but they get something. And it comes at a cost because the GM also gets to choose an effect. Remember, also, that the rules for interpreting a failed roll only apply to PCs. For the GM, a success is a success and a failure is a failure (See chapter 2 for more details).
 
 ### Why Succeed on a Failed Roll?
 
@@ -4692,7 +4692,7 @@ A few attributes can be used for damaging attacks in special circumstances in wh
 
 ### Probably Never
 
-The remaining attributes don’t really lend themselves to damage. Without a VERY good explanation, the following cannot be used for damaging attacks: fortitude, learning, perception, will, deception, persuasion, presence, creation, prescience.
+The remaining attributes don't really lend themselves to damage. Without a VERY good explanation, the following cannot be used for damaging attacks: fortitude, learning, perception, will, deception, persuasion, presence, creation, prescience.
 
 ## Taking Your Turn
 
@@ -4739,7 +4739,7 @@ To attack a foe in an attempt to damage them, follow the steps in the Attack Sum
 
 **Melee weapon attacks** target foes that are within reach of you.
 
-**Projectile weapon attacks** can target foes within their range at no penalty. Attacks suffer disadvantage 1 per extra range increment beyond the first, to a maximum of disadvantage 2 at three times the weapon’s range.
+**Projectile weapon attacks** can target foes within their range at no penalty. Attacks suffer disadvantage 1 per extra range increment beyond the first, to a maximum of disadvantage 2 at three times the weapon's range.
 
 **Extraordinary attacks** have a range according to the attribute being used, as detailed in the Extraordinary Attack Range table. Unlike projectile weapons, extraordinary attacks cannot extend beyond their normal range.
 
@@ -4759,12 +4759,12 @@ To attack a foe in an attempt to damage them, follow the steps in the Attack Sum
 | **Step 1:** | **Melee** = Within your reach |
 | **Determine Range** | **Projectile** = Weapon range (Disadvantage 1 per extra range increment) |
 | |  **Extraordinary** |
-| | 1 - 3 = 25’ |
-| | 4 - 6 = 50’ |
-| | 7 - 9 = 75’ |
+| | 1 - 3 = 25' |
+| | 4 - 6 = 50' |
+| | 7 - 9 = 75' |
 | **Step 2:** | *If more than one target...*  |
 |  **Determine Targets** | **Melee** = Disadvantage equals total # of targets |
-| | **Ranged** = Disadvantage equals total # of targets (Max 5 targets within 25’ square) |
+| | **Ranged** = Disadvantage equals total # of targets (Max 5 targets within 25' square) |
 | | **Area** = Disadvantage varies (see below) |
 | **Step 3:** | Weapon Attacks target Guard |
 | **Determine Targeted Defense** | Extraordinary Attacks target the most logical defense |
@@ -4829,14 +4829,14 @@ You may choose from a variety of shapes when making an area attack as described 
 | - | - |
 | **Melee Attacks** | Disadvantage = number of targets. |
 | **Ranged Attacks** | Disadvantage = number of targets. |
-| | Max 5 targets. Must be within a 25’ square. |
-| **Cube** | Disadvantage = 1 per 5’ of length of cube. |
+| | Max 5 targets. Must be within a 25' square. |
+| **Cube** | Disadvantage = 1 per 5' of length of cube. |
 | **Line** | Disadvantage = 1 per 5'x10'x10' line. |
 | **Cone** | Disadvantage = 1 per 5' length of cone. |
 
 **3. Determine Targeted Defense**
 
-Every attack targets one of your foe’s defenses: Toughness, Guard, or Resolve.
+Every attack targets one of your foe's defenses: Toughness, Guard, or Resolve.
 
 Weapon attacks always target Guard.
 
@@ -4854,12 +4854,12 @@ You deal damage equal to your action roll minus the target's defense, ignoring n
 
 **Exceptional Success**
 
-If your damaging attack roll exceeds the target’s defense by 10 or more, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must
+If your damaging attack roll exceeds the target's defense by 10 or more, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must
 equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target.
 
 #### Make a Bane Attack
 
-Instead of attempting to damage a target, you may instead choose to inflict your enemy with a bane. In order to inflict a bane, you must possess an appropriate attribute of at least the bane’s power level, as
+Instead of attempting to damage a target, you may instead choose to inflict your enemy with a bane. In order to inflict a bane, you must possess an appropriate attribute of at least the bane's power level, as
 detailed in the [*bane descriptions*](#banes-list). While targets may be effected by multiple banes, you may not *stack* banes; a target cannot be inflicted with a bane it is currently suffering from, unless specified in the boon's effect (*e.g.* *Fatigued*).
 
 To resolve a bane attack, follow these steps:
@@ -4874,13 +4874,13 @@ The targeted defense is determined by the type of bane being inflicted. Consult 
 
 **3. Roll Your Attack**
 
-The [*bane descriptions*](#banes-list) also indicate which attributes can be used to inflict each bane. Make an action roll using the appropriate attribute. If your total equals or exceeds the target’s defense score, your target suffers the bane.
+The [*bane descriptions*](#banes-list) also indicate which attributes can be used to inflict each bane. Make an action roll using the appropriate attribute. If your total equals or exceeds the target's defense score, your target suffers the bane.
 
 #### Invoke a Boon
 
 \ \
 
-You can invoke boons in order to aid yourself or allies. In order to invoke a boon, you must possess an appropriate attribute of at least the boon’s power level, as detailed in the
+You can invoke boons in order to aid yourself or allies. In order to invoke a boon, you must possess an appropriate attribute of at least the boon's power level, as detailed in the
 [*boon descriptions*](#Boons List). To invoke a boon, follow these steps:
 
 **1. Determine Range and Target(s)**
@@ -4951,7 +4951,7 @@ You may move up to your speed. The base speed for characters is 30'. This moveme
 
 Special movement includes climbing, jumping, swimming, and other movement that is typically more restricted than just running across the battlefield.
 
-**Jump**. Make a Might roll. If you can’t get at least a 10’ running start, you have disadvantage 1.
+**Jump**. Make a Might roll. If you can't get at least a 10' running start, you have disadvantage 1.
 
 - **For a long jump,** you cover a number of feet equal to your roll.
 
@@ -4973,7 +4973,7 @@ Many banes will persist for a longer duration after three failed resist attempts
 
 \ \
 
-Minor actions are tasks that don’t require much time or effort, but often set up larger actions. You may take any number of minor actions on your turn, but you cannot take more than one of the same type of minor action. Minor actions include the following:
+Minor actions are tasks that don't require much time or effort, but often set up larger actions. You may take any number of minor actions on your turn, but you cannot take more than one of the same type of minor action. Minor actions include the following:
 
 -   Draw or sheathe a weapon
 -   Retrieve an item stored on your person
@@ -5009,7 +5009,7 @@ Using a focus action involves spending all of your energy and attention on one t
 
 ### Interrupt Actions
 
-In some situations, you may want to take an action in response to another combatant’s action. In these cases, you can use an interrupt action. However, whenever you use an interrupt action, you lose your major action the next time your turn in the initiative order comes up. You can use your interrupt action to attempt any of the following:
+In some situations, you may want to take an action in response to another combatant's action. In these cases, you can use an interrupt action. However, whenever you use an interrupt action, you lose your major action the next time your turn in the initiative order comes up. You can use your interrupt action to attempt any of the following:
 
 **Defend.** You may use a defend action after an enemy has rolled a successful attack against you or an ally in order to attempt to ward off the attack. Describe how you are defending and then make an action roll using an appropriate attribute (Protection, Agility, and Might are all typical examples of attributes used to defend). A single defend action can only be used to defend one target.
 
@@ -5025,7 +5025,7 @@ If a feat, perk, boon, or other source grants a *Free Action*, that action can b
 
 ## Damage and Healing
 
-Your hit points (HP) are an abstract measure of your character’s ability to ignore pain, avoid deadly blows, and maintain a presence on the battlefield in spite of wounds or exhaustion. Whenever you take damage, your hit points are reduced, and whenever you receive healing they are increased.
+Your hit points (HP) are an abstract measure of your character's ability to ignore pain, avoid deadly blows, and maintain a presence on the battlefield in spite of wounds or exhaustion. Whenever you take damage, your hit points are reduced, and whenever you receive healing they are increased.
 
 ### Finishing Blows
 
@@ -5048,7 +5048,7 @@ Lethal damage is used sparingly in Open Legend as a way for GMs to paint a pictu
 
 A creature's maximum hit point toal is reduced by the amount of lethal damage it has sustained. The maximum lethal damage a creature can accrue is equal to its maximum hit points. If a creature sustains lethal damage greater than or equal to its maximum hit point total, the creature is unconscious until it heals at least 1 hit point of lethal damage.
 
-Lethal damage is more difficult to heal then regular damage, healing at a rate of 1 hit point per day per Fortitude attribute point (minimum of 1 hit point). With the full-time attendance of a capable healer or doctor, any number of characters who are located in the same area and avoid strenuous activity heal at an additional rate equal to their attendant’s Creation, Presence, or Learning score. Multiple attendants do not cumulatively improve this accelerated healing rate (the bonus is simply equal to the highest score among attendants).
+Lethal damage is more difficult to heal then regular damage, healing at a rate of 1 hit point per day per Fortitude attribute point (minimum of 1 hit point). With the full-time attendance of a capable healer or doctor, any number of characters who are located in the same area and avoid strenuous activity heal at an additional rate equal to their attendant's Creation, Presence, or Learning score. Multiple attendants do not cumulatively improve this accelerated healing rate (the bonus is simply equal to the highest score among attendants).
 
 For example, a warrior with Fortitude 4 heals 4 lethal damage per day on their own. With the assistance of a physician with a learning score of 8, the same warrior would heal at a rate of 12 lethal damage per day.
 
@@ -5073,7 +5073,7 @@ The thrill of adventure, the satisfaction of character development, and the joy 
 
 In Open Legend, the primary way that players gain more power is by gaining experience points (XP) and reaching higher character levels, thus increasing their attribute scores and unlocking new feats, banes, and boons. Every XP that players receive grants them 1 feat point and 3 attribute points, and every 3 XP results in a new level.
 
-Rather than constantly awarding different experience point values to different monsters or types of challenges, Open Legend uses a very simple method of determining when players level up: the GM. That’s right. You get to decide when your players gain more power. Here are two methods you can use to decide how to award XP:
+Rather than constantly awarding different experience point values to different monsters or types of challenges, Open Legend uses a very simple method of determining when players level up: the GM. That's right. You get to decide when your players gain more power. Here are two methods you can use to decide how to award XP:
 
 **Big Milestones.** You could award a new level whenever the players complete a major quest, defeat a powerful foe, or neutralize a serious threat. With this method, you may want to plan out the big milestones that you can foresee being accomplished in your campaign. Whenever your players reach one of these milestones, you give them 3 XP and thus a new level. A milestone map might look something like this:
 
@@ -5081,7 +5081,7 @@ Rather than constantly awarding different experience point values to different m
 
 - **Level 3:** The heroes discover the Cult of the Dragon.
 
-- **Level 4:** The heroes prevent the cult’s Ritual of Three
+- **Level 4:** The heroes prevent the cult's Ritual of Three
   from being completed.
 
 - **Level 5:** The heroes retrieve the treasure at the bottom of the Sunken Star.
@@ -5092,26 +5092,26 @@ Rather than constantly awarding different experience point values to different m
 
 - **Level 8:** The heroes discover the secret of the Ruins of Mastika.
 
-- **Level 9:** The heroes find a way to weaken Dezzer Kai’s power over the land.
+- **Level 9:** The heroes find a way to weaken Dezzer Kai's power over the land.
 
 - **Level 10:** The heroes defeat Dezzer Kai.
 
 
-**Time Played.** An easy way to schedule rewards is simply to give players 1 XP at the end of each session. This way, they’ll always look forward to gaining that little extra bit of power that comes from attributes and feats. Occasionally, you may decide to switch it up a bit and award players with 2 or even 3 XP if they accomplished a particularly important goal. With this method, you don’t have to plan out a campaign’s milestones ahead of time, but you may need to adapt on the fly to your players' increasing power.
+**Time Played.** An easy way to schedule rewards is simply to give players 1 XP at the end of each session. This way, they'll always look forward to gaining that little extra bit of power that comes from attributes and feats. Occasionally, you may decide to switch it up a bit and award players with 2 or even 3 XP if they accomplished a particularly important goal. With this method, you don't have to plan out a campaign's milestones ahead of time, but you may need to adapt on the fly to your players' increasing power.
 
 ### Beyond 10th Level
 
-Although officially, Open Legend was designed with a maximum character level of 10, there is no reason you can’t extend your campaign beyond this threshold if you are up for the challenge (higher level characters can be difficult to manage and properly engineer challenges for). Feel free to continue the campaign for as many levels as is fun for both you and your players. To do so, simply continue the established progression of 3 XP to gain a new level, with each XP also providing 1 feat point and 3 attribute points.
+Although officially, Open Legend was designed with a maximum character level of 10, there is no reason you can't extend your campaign beyond this threshold if you are up for the challenge (higher level characters can be difficult to manage and properly engineer challenges for). Feel free to continue the campaign for as many levels as is fun for both you and your players. To do so, simply continue the established progression of 3 XP to gain a new level, with each XP also providing 1 feat point and 3 attribute points.
 
 #### All That Glitters: Giving Players More Wealth
 
 In addition to power, most players enjoy being able to have more influence on the campaign world by amassing hoards of treasure. With money comes the ability to buy better equipment, employ hirelings, construct fortifications, and even raise armies.
 
-Chapter 4 explains Open Legend’s simplified wealth system, and the Wealth Overview Table indicates the typical wealth score of PCs at varying experience levels. Players start with a wealth score of 2 and it will increase whenever the GM decides. Just as experience levels represent a vast increase in power, new wealth scores drastically improve the players’ access to valuable goods. A character who goes from wealth 3 to 4, for example, has progressed from being able to purchase a fine horse to being able to buy a siege engine.
+Chapter 4 explains Open Legend's simplified wealth system, and the Wealth Overview Table indicates the typical wealth score of PCs at varying experience levels. Players start with a wealth score of 2 and it will increase whenever the GM decides. Just as experience levels represent a vast increase in power, new wealth scores drastically improve the players' access to valuable goods. A character who goes from wealth 3 to 4, for example, has progressed from being able to purchase a fine horse to being able to buy a siege engine.
 
-You can use this table as a rough guideline for when to give players more wealth, particularly if you have also created an outline of milestones for granting experience levels. For example, the table shows that by 4th level, a typical character should have progressed to wealth score 4. Using the experience level milestone plan detailed previously, we could decide that after stopping the first threat to Woodshold, the people of the town take up a collection to reward the heroes. We can also plan to give the Cult of the Dragon a horde of treasure that will again increase the party’s wealth score.
+You can use this table as a rough guideline for when to give players more wealth, particularly if you have also created an outline of milestones for granting experience levels. For example, the table shows that by 4th level, a typical character should have progressed to wealth score 4. Using the experience level milestone plan detailed previously, we could decide that after stopping the first threat to Woodshold, the people of the town take up a collection to reward the heroes. We can also plan to give the Cult of the Dragon a horde of treasure that will again increase the party's wealth score.
 
-However you plan to award wealth, you can see that the general recommendation on the table is for a PC’s wealth score to increase twice every three levels.
+However you plan to award wealth, you can see that the general recommendation on the table is for a PC's wealth score to increase twice every three levels.
 
 #### Wealth Overview
 
@@ -5126,24 +5126,24 @@ However you plan to award wealth, you can see that the general recommendation on
 | 2 | skilled laborer, town guardsman, 1st level hero | martial weapons, scale mail armor, a good horse, a raft |
 | 3 | master artisan, village mayor | full plate armor, silver weapons, a small boat, a fine horse |
 | 4 | 4th level hero, noble, city mayor | elven full plate, a small ship, a siege engine |
-| 5 | lord of a realm, thieves’ guild master in a large city | a large cargo ship, a city wall |
+| 5 | lord of a realm, thieves' guild master in a large city | a large cargo ship, a city wall |
 | 6 | 7th level hero | a large warship |
 | 7 | king | a stronghold, startup funding for a new town |
 | 8 | 10th level hero | startup funding for a new city, an army of 10,000 |
 | 9 | emperor| a castle, an army of 50,000 |
 
 
-If you or your players have a background with other game systems, in which they may have regularly looted every corpse, scavenged every piece of equipment, and dutifully tracked every single gold piece, then Open Legend’s wealth system might initially feel a bit awkward. If it does, consider some of the following tips:
+If you or your players have a background with other game systems, in which they may have regularly looted every corpse, scavenged every piece of equipment, and dutifully tracked every single gold piece, then Open Legend's wealth system might initially feel a bit awkward. If it does, consider some of the following tips:
 
-**NPCs still have stuff on them.** Just because you don’t need to spend hours tracking every piece of loot that the players cut from a corpse doesn’t mean that they don’t have stuff on them. It just fades into the background so that you can focus on the story.
+**NPCs still have stuff on them.** Just because you don't need to spend hours tracking every piece of loot that the players cut from a corpse doesn't mean that they don't have stuff on them. It just fades into the background so that you can focus on the story.
 
-Think of any movie or novel. How often does the action focus on the characters picking at the defeated bodies of the antagonists? Rarely. And, if they do take something from a foe, it’s usually to serve the plot.
+Think of any movie or novel. How often does the action focus on the characters picking at the defeated bodies of the antagonists? Rarely. And, if they do take something from a foe, it's usually to serve the plot.
 
-So, when a combat encounter ends, instead of listing off how many crossbow bolts each bandit has on them, just tell the party that they find a few valuables to add to their ever-growing stash, but that it’s still not enough to increase their wealth score. If a player does legitimately need another clip of ammo or another dagger or a new cloak, then you can decide whether or not it makes sense for the NPCs to have them.
+So, when a combat encounter ends, instead of listing off how many crossbow bolts each bandit has on them, just tell the party that they find a few valuables to add to their ever-growing stash, but that it's still not enough to increase their wealth score. If a player does legitimately need another clip of ammo or another dagger or a new cloak, then you can decide whether or not it makes sense for the NPCs to have them.
 
-**Wealth represents influence.** Since players aren’t tracking individual gold pieces, dollars, or gems, situations like bribery might initially prove to be a bit sticky. But a good guideline is that a character can easily use money to influence someone else of a lower wealth score.
+**Wealth represents influence.** Since players aren't tracking individual gold pieces, dollars, or gems, situations like bribery might initially prove to be a bit sticky. But a good guideline is that a character can easily use money to influence someone else of a lower wealth score.
 
-If the recipient of the bribe has the **same wealth score** as the character, then it would be considered a “major expense”, which means that it can be done, but the expense taxes resources such that new goods at that level or higher can’t be acquired for two weeks. If the bribe recipient is **one wealth level higher** than the character’s Wealth Score, the cost is so great that the character’s Wealth Score is permanently reduced by 1. Bribing someone more than one Wealth level higher is impossible without other factors in play.
+If the recipient of the bribe has the **same wealth score** as the character, then it would be considered a “major expense”, which means that it can be done, but the expense taxes resources such that new goods at that level or higher can't be acquired for two weeks. If the bribe recipient is **one wealth level higher** than the character's Wealth Score, the cost is so great that the character's Wealth Score is permanently reduced by 1. Bribing someone more than one Wealth level higher is impossible without other factors in play.
 
 So, a character with a wealth score of 2 will be inconvenienced in bribing a town guard, and a character probably needs a wealth score of 5 before they can easily bribe powerful political figures like the town mayor.
 
@@ -5151,7 +5151,7 @@ Keep these same guidelines in mind when it comes to arbitrating similar situatio
 
 ### Monsters and NPC Statistics
 
-Many of the monsters and NPCs that the PCs encounter throughout their journey will be used solely for the purposes of role playing or setting the mood. These sort of background characters typically don’t need a full array of attributes, feats, and favored banes because, more likely than not, you’ll never make a single action roll for them. Angus the Blacksmith, for example, might spice up the town bazaar a bit with his Scottish accent and epic tales of fraudulent accomplishments - but your party is never going to need to engage him in combat.
+Many of the monsters and NPCs that the PCs encounter throughout their journey will be used solely for the purposes of role playing or setting the mood. These sort of background characters typically don't need a full array of attributes, feats, and favored banes because, more likely than not, you'll never make a single action roll for them. Angus the Blacksmith, for example, might spice up the town bazaar a bit with his Scottish accent and epic tales of fraudulent accomplishments - but your party is never going to need to engage him in combat.
 
 A good deal of your monsters and NPCs, however, will require statistical descriptions to use for combat or social encounters. This section will describe two ways that you can build these statistics: the complex build and the simple build.
 
@@ -5159,13 +5159,13 @@ A good deal of your monsters and NPCs, however, will require statistical descrip
 
 When designing an NPC using the complex build, you simply create the NPC as if it was a player character. Select an appropriate level and use the instructions in chapter one to assign attributes, feats, and other defining characteristics.
 
-The complex build is a good option when you are creating a very important villain or ally who will play a major role in the story line. This process can take a while, so it’s not worth going through with underlings, henchmen, or beasts who are only going to be present for a single scene.
+The complex build is a good option when you are creating a very important villain or ally who will play a major role in the story line. This process can take a while, so it's not worth going through with underlings, henchmen, or beasts who are only going to be present for a single scene.
 
 #### Simple Build
 
-The simple build option is useful when you need to come up with statistics on the fly. For example, imagine the party fails an action roll to move stealthily through a swamp to avoid the local denizens. You decide that they have attracted the attention of a handful of poisonous serpents that lair in the swamp, but you don’t have any stats written up for these monsters. In this situation, you could use the simple build rules to get combat rolling quickly.
+The simple build option is useful when you need to come up with statistics on the fly. For example, imagine the party fails an action roll to move stealthily through a swamp to avoid the local denizens. You decide that they have attracted the attention of a handful of poisonous serpents that lair in the swamp, but you don't have any stats written up for these monsters. In this situation, you could use the simple build rules to get combat rolling quickly.
 
-Use the NPC Simple Build Table to determine the monster’s most relevant statistics. For the hit point and defense columns, choose values within the given ranges based on the strengths and weaknesses of the monster you are building. Choose 1 to 3 primary attributes that will form the main basis of the monster’s attacks and actions, and then choose as many secondary attributes as you need in order to define the monster’s other capabilities.
+Use the NPC Simple Build Table to determine the monster's most relevant statistics. For the hit point and defense columns, choose values within the given ranges based on the strengths and weaknesses of the monster you are building. Choose 1 to 3 primary attributes that will form the main basis of the monster's attacks and actions, and then choose as many secondary attributes as you need in order to define the monster's other capabilities.
 
 #### NPC Simple Build
 
@@ -5252,7 +5252,7 @@ You may use your attacks to make any combination of bane or damaging attacks, bu
 
 A Boss is a single monster or NPC that is capable of taking on a group of characters due to extraordinary prowess in combat. Bosses could be epic villains that the party has been pursuing for the entire campaign, such as the Lich King Akrakus, or they could be monstrous beasts with little backstory that simply serve as a dramatic milestone in the course of a larger adventure, such as a bridge troll that must be defeated before the PCs can progress. Other examples of bosses include the Kraken, a legendary gunslinger, a dragon, or the general of an alien armada.
 
-When you decide that one of your monsters or NPCs merits boss status, use the Boss Monster Build Table to generate statistics in the same way you would if using the simple build rules described previously. You’ll notice that bosses have more hit points, higher defenses, and better attributes in order to account for their ability to take on entire parties of PCs alone. When using the complex build, you can alter your villain’s hit points and defenses based on this table to better represent the appropriate strength of a boss.
+When you decide that one of your monsters or NPCs merits boss status, use the Boss Monster Build Table to generate statistics in the same way you would if using the simple build rules described previously. You'll notice that bosses have more hit points, higher defenses, and better attributes in order to account for their ability to take on entire parties of PCs alone. When using the complex build, you can alter your villain's hit points and defenses based on this table to better represent the appropriate strength of a boss.
 
 
 \NextTableColumns{OLT{.16}OCT{.16}OCT{.17}OCT{.17}OCT{.17}OCT{.17}}
@@ -5274,9 +5274,9 @@ When you decide that one of your monsters or NPCs merits boss status, use the Bo
 
 **Boss Actions**
 
-In addition to its normal allotment of actions, a boss will also receive one or more boss actions on its turn. When rolling initiative for a boss, make an extra number of initiative rolls for each boss action. When arranging the initiative order, there must be at least one PC between each of the boss’s turns. If necessary, move the “boss action” turns lower in the order to accommodate this requirement.
+In addition to its normal allotment of actions, a boss will also receive one or more boss actions on its turn. When rolling initiative for a boss, make an extra number of initiative rolls for each boss action. When arranging the initiative order, there must be at least one PC between each of the boss's turns. If necessary, move the “boss action” turns lower in the order to accommodate this requirement.
 
-During combat, the boss monster’s highest initiative count indicates its normal turn, during which it gets the usual allotment of major, move, and minor actions. Each of the boss’s lower counts in the initiative are boss actions, which allow the boss to make one major action.
+During combat, the boss monster's highest initiative count indicates its normal turn, during which it gets the usual allotment of major, move, and minor actions. Each of the boss's lower counts in the initiative are boss actions, which allow the boss to make one major action.
 
 
 ## Planning Combat Encounters
@@ -5285,7 +5285,7 @@ The build rules just explained help you create individual monsters or NPCs for t
 
 ### Encounter Difficulty
 
-When designing a combat encounter, decide if you want it to be easy, moderate, or hard. An **easy encounter** shouldn’t present a significant threat to the PCs unless luck is wildly against them or they make a series of poor decisions. A **moderate encounter** will challenge the PCs, but they are still likely to come out on top. A **hard encounter** will push them to the limits, and may end in defeat or the death of one or more characters.
+When designing a combat encounter, decide if you want it to be easy, moderate, or hard. An **easy encounter** shouldn't present a significant threat to the PCs unless luck is wildly against them or they make a series of poor decisions. A **moderate encounter** will challenge the PCs, but they are still likely to come out on top. A **hard encounter** will push them to the limits, and may end in defeat or the death of one or more characters.
 
 Use the Encounter Difficulty Table to determine how many total monster levels you should include in your combat.
 

--- a/core/src/00-introduction/01-introduction.md
+++ b/core/src/00-introduction/01-introduction.md
@@ -10,12 +10,12 @@
 
 *The death throes of the orcs can be heard two realms over as they fall in waves to the heroes making their last stand upon the Ruins of Ravenwatch. Still, there is no end in sight to the horde that blackens the hills like a swarm of locusts.*
 
-*“They come for the Stone,” grunts a dwarf, pulling his axe from the skull of another pig-headed orc. “Just give it to them, and maybe we’ll get out of this alive.”*
+*“They come for the Stone,” grunts a dwarf, pulling his axe from the skull of another pig-headed orc. “Just give it to them, and maybe we'll get out of this alive.”*
 
-*It is an elven maiden, tall and clad in battleworn mail, who replies: “I’ll have no bard sing tales of Luthiel the Cowardly, who surrendered to orc scum while still she drew breath.”*
+*It is an elven maiden, tall and clad in battleworn mail, who replies: “I'll have no bard sing tales of Luthiel the Cowardly, who surrendered to orc scum while still she drew breath.”*
 
 *As elf and dwarf bicker, a grey haired man, cloaked in emerald, stands tall atop a boulder at the center of the ruins. His eyes stare distantly, like sharp daggers, at the golden sun landing upon the horizon. With a smirk, he raises his gnarled oaken staff to the sky,
-where the gathering storm clouds crackle with the fury of nature’s electric potential. “Gentleman, lady…” speaks the druid with soft confidence, “I think the winds have turned in our favor.”*
+where the gathering storm clouds crackle with the fury of nature's electric potential. “Gentleman, lady…” speaks the druid with soft confidence, “I think the winds have turned in our favor.”*
 
 * * *
 
@@ -23,13 +23,13 @@ where the gathering storm clouds crackle with the fury of nature’s electric po
 > ### Why Open Legend?
 If you have played roleplaying games in the past, you may be wondering What makes Open Legend worth my time? What makes it different?
 >
->The secret’s in the title: Open. Everything about the game is about opening up the doors of possibility so that every table tells a legend worth telling. Here are a few of the possibilities that Open Legend offers.
+>The secret's in the title: Open. Everything about the game is about opening up the doors of possibility so that every table tells a legend worth telling. Here are a few of the possibilities that Open Legend offers.
 >
->**Open Source**. That’s right. The core rules are with accomodation for [commercial](/commercial-terms) and [non-commercial](/noncommercial-terms) derivative works. We know the public will love the game as much as we do, and we hope they’ll spread the love by publishing their own adventures, rules supplements, and more.
+>**Open Source**. That's right. The core rules are with accomodation for [commercial](/commercial-terms) and [non-commercial](/noncommercial-terms) derivative works. We know the public will love the game as much as we do, and we hope they'll spread the love by publishing their own adventures, rules supplements, and more.
 >
->**Open Dice**. In Open Legend, dice explode! That means that whenever ANY die rolls maximum, you get to reroll it and add the new roll to your total, ad infinitum. The volatile nature of dice rolling makes every roll count, and each session of Open Legend is full of tense moments when the tides can turn at a moment’s notice, for better or worse.
+>**Open Dice**. In Open Legend, dice explode! That means that whenever ANY die rolls maximum, you get to reroll it and add the new roll to your total, ad infinitum. The volatile nature of dice rolling makes every roll count, and each session of Open Legend is full of tense moments when the tides can turn at a moment's notice, for better or worse.
 >
->**Open Legend**. You get to tell the story that you want to tell, with the characters you want to play. You aren’t tied down to specific class, archetype, or race combinations. The only limit is your imagination (and maybe the GM’s veto power). Rather than a list of set classes with a menu of skills to pick from, you start the game with attribute points that you spend as you wish to give your character the powers they need.
+>**Open Legend**. You get to tell the story that you want to tell, with the characters you want to play. You aren't tied down to specific class, archetype, or race combinations. The only limit is your imagination (and maybe the GM's veto power). Rather than a list of set classes with a menu of skills to pick from, you start the game with attribute points that you spend as you wish to give your character the powers they need.
 
 Welcome to Open Legend, a tabletop roleplaying game (or RPG) in which the players take the part of mighty heroes and wicked villains in order to tell stories of epic proportion. As in the vignettes above, every game of Open Legend revolves around intrepid characters performing heroic deeds. They will fight mythic beasts, outsmart cunning foes, break ancient curses, crack baffling cases, discover untold treasures, and more.
 
@@ -37,7 +37,7 @@ If you have never played a roleplaying game before, you can think of it as a mov
 
 The rest of the players take the role of **Player Characters** (or PCs). The PCs are the protagonists of the story. In a high fantasy setting, one PC might be a dwarven warrior with a lust for gems, another an immortal elven wizard whose only desire is knowledge, and still another a half-angelic priest who travels the world in order to inspire others to act justly. In another game of Open Legend, the players might star as a rag tag crew of space pirates living from score to score on their barely functioning merchant ship. All the common tropes could make an appearance: the reckless pilot, the brash captain with a troubled past, the hired gun, the stowaway, and the engineer who gets along with the ship better than with the crew.
 
-Whatever the motivation of their characters, the players share a common goal: to take the plot and setting established by the GM and have fun. At some tables, this might look like J.R.R Tolkien’s *Lord of the Rings*. In others, it might look more like *Monty Python and the Holy Grail*. Whatever fun looks like at your table, Open Legend will be a part of it.
+Whatever the motivation of their characters, the players share a common goal: to take the plot and setting established by the GM and have fun. At some tables, this might look like J.R.R Tolkien's *Lord of the Rings*. In others, it might look more like *Monty Python and the Holy Grail*. Whatever fun looks like at your table, Open Legend will be a part of it.
 
 This is your story. Tell it.
 
@@ -51,22 +51,22 @@ As storytellers, we love intricate plotlines that feature characters of depth an
 
 What we want to do is game. And that means we need rules.
 
-Without well-defined rules, the decisions made by players and GMs can seem arbitrary or inconsistent. The GM may feel overburdened by a constant need to recall past rulings that they have made, and the players may feel like their decisions don’t actually matter because the GM can interpret them however they want. This is the opposite of how a baseball ref operates. The ref doesn’t need to create new rules for every play that they call. The rules of the game are already spelled out. They just need to interpret and apply them.
+Without well-defined rules, the decisions made by players and GMs can seem arbitrary or inconsistent. The GM may feel overburdened by a constant need to recall past rulings that they have made, and the players may feel like their decisions don't actually matter because the GM can interpret them however they want. This is the opposite of how a baseball ref operates. The ref doesn't need to create new rules for every play that they call. The rules of the game are already spelled out. They just need to interpret and apply them.
 
-*Open Legend* was designed to provide enough rules so that players have a clear framework to guide their play, but not so many rules that the game gets bogged down by them. You spend your day job worrying about bookkeeping and policies. We don’t want the gaming table to feel like that, and we designed *Open Legend* to focus on the fun rather than the homework.
+*Open Legend* was designed to provide enough rules so that players have a clear framework to guide their play, but not so many rules that the game gets bogged down by them. You spend your day job worrying about bookkeeping and policies. We don't want the gaming table to feel like that, and we designed *Open Legend* to focus on the fun rather than the homework.
 
-For example, you won’t have long lists of resources to manage. Any abilities that you can use or spells you can cast in *Open Legend* can be used at-will. Likewise, spellcasters, psions, and techies don’t need to worry about poring over page after page of power descriptions in order to make the right
+For example, you won't have long lists of resources to manage. Any abilities that you can use or spells you can cast in *Open Legend* can be used at-will. Likewise, spellcasters, psions, and techies don't need to worry about poring over page after page of power descriptions in order to make the right
 choices. Instead, *Open Legend* uses a system of **banes** and **boons**, or status effects, that any character can apply if he is built to do so.
 
-Other mechanics that will ensure that you can focus on the story you want to tell include simplified wealth and encumbrance systems. In *Open Legend*, you’ll never need to record a single gold piece on your character sheet or even think about how many pounds your revolver weighs.
+Other mechanics that will ensure that you can focus on the story you want to tell include simplified wealth and encumbrance systems. In *Open Legend*, you'll never need to record a single gold piece on your character sheet or even think about how many pounds your revolver weighs.
 
 *Open Legend* straddles the line by giving the best of both worlds, emphasizing both storytelling and strategy at the same time, placing less restrictions on both.
 
-We hope that we’ve built a game for players who love to tell a good story but don’t want every decision to be made on a whim.
+We hope that we've built a game for players who love to tell a good story but don't want every decision to be made on a whim.
 
-We hope that we’ve built a game for players who love to shake the dice and see them roll but don’t want to spend hours min-maxing their characters.
+We hope that we've built a game for players who love to shake the dice and see them roll but don't want to spend hours min-maxing their characters.
 
-Most of all, we hope that we’ve built a game for players like you.
+Most of all, we hope that we've built a game for players like you.
 
 ## The Core Mechanic: The Action Roll ##
 
@@ -74,7 +74,7 @@ Most meaningful tasks that a character attempts in *Open Legend* will be determi
 
 To determine the outcome, you roll 1d20 plus any bonus dice granted by your character's attribute that is most relevant to the task. Any dice that roll the maximum possible explode, which means you can roll them again and add the new total to your action roll as well. Continue rerolling dice until none of them explode.
 
-Add all of the dice together to find your total action roll. If your total is equal to or greater than the action’s Challenge Rating, then you succeed. Otherwise, the GM decides that you either succeed with a twist or fail in a way that allows the story to progress.
+Add all of the dice together to find your total action roll. If your total is equal to or greater than the action's Challenge Rating, then you succeed. Otherwise, the GM decides that you either succeed with a twist or fail in a way that allows the story to progress.
 
 | THE ACTION ROLL |
 | :-: |
@@ -83,13 +83,13 @@ Add all of the dice together to find your total action roll. If your total is eq
 | If the action roll... | then the result is... |
 | :- | :-- |
 | equals or exceeds the Challenge Rating, | the player succeeds. |
-| is less than the Challenge Rating, | the player succeeds with a twist. <br /> - OR - <br /> *the player fails but the story progresses*. (GM’s Choice) |
+| is less than the Challenge Rating, | the player succeeds with a twist. <br /> - OR - <br /> *the player fails but the story progresses*. (GM's Choice) |
 
 > ### Example Action Roll
 >
-> An adventuring party is traveling through the Darkwood, a forest cursed with malignant energy and cast in shadows at every turn. The party spies a gathering of lights in the distance ahead. At the same time, though, a Shade Demon has crept up behind the heroes. The GM tells Imladril, the elven ranger who is at the back of the marching order, to make a Perception roll against a Challenge Rating of 18. Imladril’s Perception score of 5 grants him a 2d6 bonus to Perception action rolls, so he grabs 1d20 + 2d6 and lets them fly.
+> An adventuring party is traveling through the Darkwood, a forest cursed with malignant energy and cast in shadows at every turn. The party spies a gathering of lights in the distance ahead. At the same time, though, a Shade Demon has crept up behind the heroes. The GM tells Imladril, the elven ranger who is at the back of the marching order, to make a Perception roll against a Challenge Rating of 18. Imladril's Perception score of 5 grants him a 2d6 bonus to Perception action rolls, so he grabs 1d20 + 2d6 and lets them fly.
 >
-> Imladril rolls a 7 on the d20, and the d6s come up 1 and 6. Since the 6 explodes, the die is rolled again and it comes up a 3, for a grand total of 17 (7+1+6+3), just shy of the required 18. The GM decides to allow Imladril to **succeed with a twist**, so the GM rules that Imladril hears the demon fast enough to alert the party, but that the demon has already closed into melee distance and is able to knock the ranger’s bow out of his hands.
+> Imladril rolls a 7 on the d20, and the d6s come up 1 and 6. Since the 6 explodes, the die is rolled again and it comes up a 3, for a grand total of 17 (7+1+6+3), just shy of the required 18. The GM decides to allow Imladril to **succeed with a twist**, so the GM rules that Imladril hears the demon fast enough to alert the party, but that the demon has already closed into melee distance and is able to knock the ranger's bow out of his hands.
 >
 > Alternatively, the GM could decide that Imladril **fails, but the story progresses**. For example, the GM rules that the demon is able to grab the ranger and drag him silently into the darkness completely unbeknownst to the rest of the party distracted by the lights in the distance.
 

--- a/core/src/01-character-creation/01-chapter-one.md
+++ b/core/src/01-character-creation/01-chapter-one.md
@@ -1,6 +1,6 @@
 # Chapter 1: Character Creation #
 
-Before you can start telling your story, you’ll need a character to play. This chapter will offer you step-by-step instructions to create your own hero. In *Open Legend*, you typically begin as a level one character. As you complete missions or quests and gain more experience as a hero, you’ll level up and gain more power. These rules explain how to create a character starting at level one. Later, you’ll learn what to do when you level up.
+Before you can start telling your story, you'll need a character to play. This chapter will offer you step-by-step instructions to create your own hero. In *Open Legend*, you typically begin as a level one character. As you complete missions or quests and gain more experience as a hero, you'll level up and gain more power. These rules explain how to create a character starting at level one. Later, you'll learn what to do when you level up.
 
 Before reading on, take a minute and think of your favorite movies, books, or video games.
 
@@ -8,7 +8,7 @@ Before reading on, take a minute and think of your favorite movies, books, or vi
 
 *Who inspired you?*
 
-Now that you’ve got some of your favorites in mind, let’s create your character.
+Now that you've got some of your favorites in mind, let's create your character.
 
 ### Choose an Example Character & Modify It
 
@@ -18,31 +18,31 @@ For anyone who feels they could benefit from some inspiration, you can easily ma
 
 ## Step 1: Describe Your Character
 
-*Open Legend* is a role playing game, which means your character will need more depth than merely a selection of attributes, feats, perks, and gear that we will learn about in later steps. To make your character come to life, add some of the following details. If you can’t think of anything yet, try to fill in the blanks during your first couple of play sessions as you get to know your character better.
+*Open Legend* is a role playing game, which means your character will need more depth than merely a selection of attributes, feats, perks, and gear that we will learn about in later steps. To make your character come to life, add some of the following details. If you can't think of anything yet, try to fill in the blanks during your first couple of play sessions as you get to know your character better.
 
 **A heroic name.** Be sure to check with your GM to see if they have any particular setting in mind. Phil the Fighter would feel quite out of place next to Therilas Windcaster and Gorion Skullcleaver.
 
-**Your race.** Your decision of race is limited only by your imagination, the setting, and the constraints provided by your GM. A typical fantasy campaign might feature dwarves, elves, halflings, celestials, and dragon-blooded. If you are playing in a futuristic space opera on the fringes of the galaxy, your GM might have several alien races to choose from. Some campaigns, such as a mystery of Lovecraftian horror, might allow only for regular old humans. Really, though, as long as it is approved by your GM, you can play anything you would like, whether that’s a psionic humanoid tiger, a 3-inch tall pixie, or anything in between.
+**Your race.** Your decision of race is limited only by your imagination, the setting, and the constraints provided by your GM. A typical fantasy campaign might feature dwarves, elves, halflings, celestials, and dragon-blooded. If you are playing in a futuristic space opera on the fringes of the galaxy, your GM might have several alien races to choose from. Some campaigns, such as a mystery of Lovecraftian horror, might allow only for regular old humans. Really, though, as long as it is approved by your GM, you can play anything you would like, whether that's a psionic humanoid tiger, a 3-inch tall pixie, or anything in between.
 
 As part of deciding your race, you should also choose your **size**: small, medium, or large. A medium character is roughly the size of an average human. Small creatures range from about 2 - 4 feet in height, while large creatures are about 7 - 10 feet tall. A large creature occupies a 10'x10' square in combat and has a 10' reach (see Chapter 6: Combat for details). The GM may assign advantage or disadvantage during situations in which your size is relevant. For example, small creatures may gain advantage on rolls to hide and receive disadvantage on rolls to kick down a door. Likewise, large creatures might suffer disadvantage on attack rolls when fighting in confined spaces but gain advantage on rolls to intimidate smaller creatures.
 
 At the GM's discretion, you may choose to be even smaller or larger than the sizes described above. A large creature's reach is always equal to the length of its base. So, a giant with a 15'x15' base would have a 15' reach. Small creatures always have at least a 5' reach.
 
 > ### No Racial Abilities or Adjustments?
-> In Open Legend, races do not provide specific mechanical costs and benefits. Instead, you’ll have a chance to further define your character in the a later step of character creation by choosing your perks and flaws. Some or all of your decisions at that stage may be influenced by your race, and you are encouraged to explain to the rest of your group how your race informs your choice of perks and flaws. For example, if you are playing the aforementioned psionic humanoid tiger, you might choose the *scent* perk to highlight your hunter’s bloodline and the *observant* perk to simulate your extrasensory perception. Likewise, you could select the *hot tempered* flaw to represent the savage animal that still lurks beneath your intelligent outer shell.
+> In Open Legend, races do not provide specific mechanical costs and benefits. Instead, you'll have a chance to further define your character in the a later step of character creation by choosing your perks and flaws. Some or all of your decisions at that stage may be influenced by your race, and you are encouraged to explain to the rest of your group how your race informs your choice of perks and flaws. For example, if you are playing the aforementioned psionic humanoid tiger, you might choose the *scent* perk to highlight your hunter's bloodline and the *observant* perk to simulate your extrasensory perception. Likewise, you could select the *hot tempered* flaw to represent the savage animal that still lurks beneath your intelligent outer shell.
 
 **Two exceptional physical traits.** Think of the first two features that other characters notice when they see you. Do your eyes glow red when you are angry? Are you seven feet tall? Is your hair a rainbow hue?
 
-**Two defining social traits.** Maybe you stutter when you’re nervous. Maybe you don’t trust anyone until they’ve proven themselves to you. Or, perhaps, you are a winsome bard who almost always talks in sing-song. Your two social traits should be characteristics that others will learn shortly after getting to know you.
+**Two defining social traits.** Maybe you stutter when you're nervous. Maybe you don't trust anyone until they've proven themselves to you. Or, perhaps, you are a winsome bard who almost always talks in sing-song. Your two social traits should be characteristics that others will learn shortly after getting to know you.
 
-**A secret.** Your secret is something that other characters probably won’t find out about until they’ve gotten to know you quite well. It’s also a seed for great adventure that the GM can weave into his campaign.
+**A secret.** Your secret is something that other characters probably won't find out about until they've gotten to know you quite well. It's also a seed for great adventure that the GM can weave into his campaign.
 
 > ### Example Character Secrets
 > Before Volkor changed his name and began wandering the land as a barbarian sellsword, he was heir to the throne.
 >
 > * * * * *
 >
-> Sir Thomas Tuckburrough served as an assassin for the local thieves guild until a job went bad and he murdered an innocent child--that’s when he began his road to the priesthood.
+> Sir Thomas Tuckburrough served as an assassin for the local thieves guild until a job went bad and he murdered an innocent child--that's when he began his road to the priesthood.
 >
 > * * * * *
 >
@@ -51,12 +51,12 @@ At the GM's discretion, you may choose to be even smaller or larger than the siz
 
 ## Step 2: Choose Attributes
 
-Attributes are the backbone of every character in *Open Legend*. They define what your character can and can’t do--the spheres they excel in, as well as their greatest weaknesses. Whenever your character attempts a heroic action in Open Legend, you’ll look to your attributes to see how well you succeed or fail.
+Attributes are the backbone of every character in *Open Legend*. They define what your character can and can't do--the spheres they excel in, as well as their greatest weaknesses. Whenever your character attempts a heroic action in Open Legend, you'll look to your attributes to see how well you succeed or fail.
 
 In *Open Legend*, attributes are divided into four categories: physical,
 social, mental, and extraordinary.
 
-A character’s skill with each attribute is expressed as a score from 0 (completely unpracticed) to 9 (superhuman). A character cannot use an extraordinary attribute if they have a score of zero.
+A character's skill with each attribute is expressed as a score from 0 (completely unpracticed) to 9 (superhuman). A character cannot use an extraordinary attribute if they have a score of zero.
 
 The average commoner or craftsmen usually has scores ranging from 1 - 3 in several physical, social, and mental attributes. Extraordinary attributes are generally reserved for characters of power and note.
 
@@ -81,7 +81,7 @@ The Attributes at a Glance tables provide a quick overview of some of the common
 | | |
 | - | - |
 | **Learning** | Recall facts about history, arcane magic, the natural world, etc. |
-| **Logic** | Solve riddles, decipher a code, improvise a tool, understand the enemy’s strategy, find a loophole |
+| **Logic** | Solve riddles, decipher a code, improvise a tool, understand the enemy's strategy, find a loophole |
 | **Perception** | Sense ulterior motives, track someone, catch a gut feeling, spot a hidden foe, find a secret door |
 | **Will** | Maintain your resolve, overcome adversity, resist torture, stay awake on watch, stave off insanity |
 
@@ -113,7 +113,7 @@ The Attributes at a Glance tables provide a quick overview of some of the common
 | **Prescience** | See the future, read minds or auras, detect magic or evil, scry, communicate with extraplanar entities |
 | **Protection** | Protect from damage, break supernatural influence, dispel magic, bind demons |
 
-In *Open Legend*, you get to define your character’s strengths and weaknesses by choosing the attributes that fit your character concept. Described below are several methods by which you can assign your attributes.
+In *Open Legend*, you get to define your character's strengths and weaknesses by choosing the attributes that fit your character concept. Described below are several methods by which you can assign your attributes.
 
 ### Quick Build
 
@@ -132,7 +132,7 @@ If you are new to roleplaying games, or are just looking to get your character b
 
 ### Custom Build
 
-If you would like more control over your attributes, you can purchase them to create your own set. With this method, at first level, you have a budget of 40 attribute points to spend, and the cost of each score is defined in the Purchasing Attributes table. The highest any score can reach at first level is 5, and you don’t have to spend all of your points at character creation.
+If you would like more control over your attributes, you can purchase them to create your own set. With this method, at first level, you have a budget of 40 attribute points to spend, and the cost of each score is defined in the Purchasing Attributes table. The highest any score can reach at first level is 5, and you don't have to spend all of your points at character creation.
 
 <div class="table-no-body table-centered"></div>
 | PURCHASING ATTRIBUTES |
@@ -210,7 +210,7 @@ In the Archetype Attribute Builds table, several common fantasy archetypes are l
 
 ### Record Attribute Dice
 
-Every attribute score above 0 grants you bonus dice to increase your chance of success. Consult the Attribute Dice table for each of your attributes and record the appropriate dice. (You’ll learn what to do with these dice later on.)
+Every attribute score above 0 grants you bonus dice to increase your chance of success. Consult the Attribute Dice table for each of your attributes and record the appropriate dice. (You'll learn what to do with these dice later on.)
 
 <div class="table-no-body"></div>
 | Attribute Dice |
@@ -230,7 +230,7 @@ Every attribute score above 0 grants you bonus dice to increase your chance of s
 > ### Roll Them Bones
 > If you are new to gaming, you may not be familiar with dice notation, such as 2d6.
 >
-> As you play Open Legend, you’ll often need to roll dice to determine the outcome of actions. **Dice notation** is a shorthand way of indicating which dice to roll.
+> As you play Open Legend, you'll often need to roll dice to determine the outcome of actions. **Dice notation** is a shorthand way of indicating which dice to roll.
 >
 > Every die roll is indicated by a formula such as 3d6. The number before the *d* indicates how many dice to roll, and the number after the *d* indicates how many sides those dice have.
 >
@@ -265,7 +265,7 @@ When an enemy tries to attack you--whether with the shot of a rifle, a deft swor
 | - |
 | |
 
-**Resolve** represents your character’s ability to resist mental domination and stand brave in the face of danger. Enemies who wish to charm you, deceive you with illusions, or frighten you must target your resolve.
+**Resolve** represents your character's ability to resist mental domination and stand brave in the face of danger. Enemies who wish to charm you, deceive you with illusions, or frighten you must target your resolve.
 
 <div class="table-no-body table-no-stripes table-even-header"></div>
 | Hit Points = 2 x (Fortitude + Presence + Will) + 10 |
@@ -280,7 +280,7 @@ When an enemy tries to attack you--whether with the shot of a rifle, a deft swor
 
 ## Step 4: Purchase Feats
 
-While your character’s attributes define his skill at accomplishing
+While your character's attributes define his skill at accomplishing
 heroic tasks, his **feats** are what make him unique among other
 characters. Feats allow you to customize your character, granting him
 the ability to accomplish specific actions exceptionally well.
@@ -395,12 +395,12 @@ In addition to the descriptive details you have just created, you may also choos
 
 Perks are characteristics that describe very specific skills, attitudes, backgrounds, or opportunities that tend to give your character the upper hand in certain situations. For example, maybe you are a noble and thus able to draw favors from powerful political figures, or perhaps you once served as mechanic on a starship and those technical skills still help you out in your adventuring life today.
 
-Flaws are your Achilles’ heel. They are weaknesses that your enemies can exploit or character deficits that always seem to hold you back at just the wrong moment. Maybe you are stubborn as a mule and won’t accept a compromise under any circumstances. Perhaps your greed tends to get the best of you, and your love of coin will even trump your loyalty to your friends. Your flaws might even be physical in nature: you’re blind, missing an arm, or suffer from a wounded knee that slows you down.
+Flaws are your Achilles' heel. They are weaknesses that your enemies can exploit or character deficits that always seem to hold you back at just the wrong moment. Maybe you are stubborn as a mule and won't accept a compromise under any circumstances. Perhaps your greed tends to get the best of you, and your love of coin will even trump your loyalty to your friends. Your flaws might even be physical in nature: you're blind, missing an arm, or suffer from a wounded knee that slows you down.
 
 
 ### Activating Perks
 
-Perks provide very specific bonuses or effects in specific situations. Your perk description will explain exactly what your perk does and how often it can be activated. Some perks can be used whenever the situation merits while others are more limited. If the use of a perk relies on a situation being relevant to the sphere of influence of the perk, the GM has the final say as to whether the perk applies or not. For example, the *profession* perk provides advantage 1 to any non-combat action rolls related to your chosen profession. If a character wants to use their *profession: hunter* perk to gain advantage on a roll to track an orc, the GM would decide whether or not the PC’s experience tracking game was relevant enough to aid in the hunt for a humanoid.
+Perks provide very specific bonuses or effects in specific situations. Your perk description will explain exactly what your perk does and how often it can be activated. Some perks can be used whenever the situation merits while others are more limited. If the use of a perk relies on a situation being relevant to the sphere of influence of the perk, the GM has the final say as to whether the perk applies or not. For example, the *profession* perk provides advantage 1 to any non-combat action rolls related to your chosen profession. If a character wants to use their *profession: hunter* perk to gain advantage on a roll to track an orc, the GM would decide whether or not the PC's experience tracking game was relevant enough to aid in the hunt for a humanoid.
 
 ### Activating Flaws
 
@@ -410,14 +410,14 @@ You may not gain a legend point from the same flaw more than once per game sessi
 
 To activate a flaw, you should intentionally make a disadvantageous choice based on your flaw that creates an interesting or tense moment in the plot. When you do so, let your GM know that you are activating your flaw and describe how it is hindering your efforts or influencing your decisions. If the GM approves that your flaw is creating a significant disadvantage and advancing the story, you receive one legend point. Sometimes, the GM may recognize that you are roleplaying a flaw without you having to overtly activate it. In such cases, the GM may award you with a legend point as well.
 
-The type of hindrance caused by activating a flaw should be more than a simple reduced chance of success. Good examples of activating a flaw include putting yourself or an ally in danger, making a bad decision, wasting a resource, and missing out on an opportunity, among others. It’s also important to note that a good use of a flaw makes something new and interesting happen in the story rather than ending the narrative. For example, instead of activating a flaw to miss an attack, you might target an ally. Or, rather than activating a flaw to fail to find a secret door, you might make so much noise in your search that you attract unwanted attention.
+The type of hindrance caused by activating a flaw should be more than a simple reduced chance of success. Good examples of activating a flaw include putting yourself or an ally in danger, making a bad decision, wasting a resource, and missing out on an opportunity, among others. It's also important to note that a good use of a flaw makes something new and interesting happen in the story rather than ending the narrative. For example, instead of activating a flaw to miss an attack, you might target an ally. Or, rather than activating a flaw to fail to find a secret door, you might make so much noise in your search that you attract unwanted attention.
 
 > ### Examples of Activating Flaws
 > Oxnar the Barbarian was never known for his brains, so when the pixie promised him that eating the golden mushroom would make him as strong as a hundred mules, he gobbled it up with no questions and much gusto. A minute later he was dozing in a puddle of his own drool as the imp made off with his coin purse. The GM awards Oxnar with a legend point for effectively roleplaying his *dimwitted* flaw to his own detriment.
 >
 > * * * * *
 >
-> Normally, Celeste’s blindness from the *disabled* flaw doesn’t stop her from being one of the best shots in the Badlands. Her keen hearing and extrasensory perception more than make up for her lack of sight. The unearthly wailing of these zombie shriekers, however, have overwhelmed her senses. The player who is role-playing Celeste decides that the situation is dicey enough that she will unintentionally target one of her allies. She lets the GM know that she is specifically activating her disabled flaw, and the GM agrees that the impact is significant enough to merit a legend point for adding a new level of depth and realism to the story the group is telling together.
+> Normally, Celeste's blindness from the *disabled* flaw doesn't stop her from being one of the best shots in the Badlands. Her keen hearing and extrasensory perception more than make up for her lack of sight. The unearthly wailing of these zombie shriekers, however, have overwhelmed her senses. The player who is role-playing Celeste decides that the situation is dicey enough that she will unintentionally target one of her allies. She lets the GM know that she is specifically activating her disabled flaw, and the GM agrees that the impact is significant enough to merit a legend point for adding a new level of depth and realism to the story the group is telling together.
 >
 > * * * * *
 >
@@ -427,7 +427,7 @@ The type of hindrance caused by activating a flaw should be more than a simple r
 
 At character creation, you may select up to two perks and two flaws, and you do not have to select any. Throughout your adventures, the GM may assign you additional perks and flaws as the natural results of your deeds. For example, if your party spends several months on board a ship, the GM may reward everyone with the *profession: sailor* perk. Likewise, if you are subjected to horrible chemical burns as part of a laboratory explosion, the GM might assign you the *physical deformity* flaw to describe your scarred face.
 
-You too, may decide to adopt new perks or flaws with the GM’s approval as your character’s personality and background develop through play. Perhaps a series of encounters with powerful forces leads you to take on the *cowardly* flaw. Or maybe you spend significant downtime between adventures training with the local weaponsmith and would like to gain the *artisan* perk. The GM is the final arbiter for deciding when and under what circumstances you may choose new perks and flaws.
+You too, may decide to adopt new perks or flaws with the GM's approval as your character's personality and background develop through play. Perhaps a series of encounters with powerful forces leads you to take on the *cowardly* flaw. Or maybe you spend significant downtime between adventures training with the local weaponsmith and would like to gain the *artisan* perk. The GM is the final arbiter for deciding when and under what circumstances you may choose new perks and flaws.
 
 ### Designing Your Own Perks and Flaws
 
@@ -477,7 +477,7 @@ You serve a higher being and have earned their protection. Once per game session
 
 #### Divine Insight
 
-You possess a supernatural connection to a deity, demi-god, or other divine being which grants you otherworldly insight. Once per game session, you can choose a topic relevant to the story. The GM shares some information about that topic which might be useful. If you’ve just failed a *Learning* attribute roll and use this ability, the GM decides whether to give you information related to that roll or to give you knowledge that is completely unrelated.
+You possess a supernatural connection to a deity, demi-god, or other divine being which grants you otherworldly insight. Once per game session, you can choose a topic relevant to the story. The GM shares some information about that topic which might be useful. If you've just failed a *Learning* attribute roll and use this ability, the GM decides whether to give you information related to that roll or to give you knowledge that is completely unrelated.
 
 #### Ear of the Emperor
 
@@ -493,7 +493,7 @@ Your reputation for some outstanding virtue precedes you, and people tend to hol
 
 #### Innocent
 
-Whether from a distant fey ancestry or simply an air of naivety, you possess a childlike quality that can melt even the coldest of hearts. Once per game session, you can leverage your innocence to turn an enemy and cause them to take pity on you. The enemy might choose to look the other way when you’ve done something illegal, forgive a debt you could never pay, or vouch in your favor before the authorities.
+Whether from a distant fey ancestry or simply an air of naivety, you possess a childlike quality that can melt even the coldest of hearts. Once per game session, you can leverage your innocence to turn an enemy and cause them to take pity on you. The enemy might choose to look the other way when you've done something illegal, forgive a debt you could never pay, or vouch in your favor before the authorities.
 
 #### Jack of All Trades
 
@@ -525,7 +525,7 @@ Your keen senses allow you to notice details that others typically miss. Once pe
 
 #### Outlaw
 
-You are part of a criminal network, whether it be a thieves’ guild, band of smugglers, or otherwise. Once per game session, you can call in a favor from a contact within your network to perform a mundane task such as gathering information or arranging safe passage. If the favor puts your contact at risk, they will still perform it but may ask for an equally risky favor from you in return.
+You are part of a criminal network, whether it be a thieves' guild, band of smugglers, or otherwise. Once per game session, you can call in a favor from a contact within your network to perform a mundane task such as gathering information or arranging safe passage. If the favor puts your contact at risk, they will still perform it but may ask for an equally risky favor from you in return.
 
 #### Profession
 
@@ -533,7 +533,7 @@ Choose a specific trade, such as sailor, soldier, or miner. You know everything 
 
 #### Pure-hearted
 
-Any goodly-natured creature you encounter is friendly toward you by default rather than neutral. Circumstances can alter this, but even if rumors or actions you’ve taken would influence a good creature negatively, it remains one step friendlier than it otherwise would have been.
+Any goodly-natured creature you encounter is friendly toward you by default rather than neutral. Circumstances can alter this, but even if rumors or actions you've taken would influence a good creature negatively, it remains one step friendlier than it otherwise would have been.
 
 #### Resilient
 
@@ -545,7 +545,7 @@ You have lived a life of need, and thus know how to make do when others would go
 
 #### Scent
 
-Your sense of smell is similar to that of a wild beast. As a focus action, you can discern the number and relative location of living creatures within 60’. With an additional focus action you can lock onto a particular scent and maintain its relative location as long as it remains within 60’. Furthermore, you gain advantage 1 on attempts to track a creature if it has left a scent trail.
+Your sense of smell is similar to that of a wild beast. As a focus action, you can discern the number and relative location of living creatures within 60'. With an additional focus action you can lock onto a particular scent and maintain its relative location as long as it remains within 60'. Furthermore, you gain advantage 1 on attempts to track a creature if it has left a scent trail.
 
 #### Scholar
 
@@ -553,23 +553,23 @@ You have spent years studying a particular discipline, such as science, herbalis
 
 #### Silver Tongue
 
-You have practiced the ways of sneaking hidden charms and subliminal messages within everyday conversation. Once per session, when you converse with an intelligent creature for at least five minutes, you will learn one useful secret of the GM’s choosing about the creature.
+You have practiced the ways of sneaking hidden charms and subliminal messages within everyday conversation. Once per session, when you converse with an intelligent creature for at least five minutes, you will learn one useful secret of the GM's choosing about the creature.
 
 #### Stone Sense
 
-While underground you may fail to find what you’re looking for, but you can never be truly lost. You can always find your way back to the entrance through which you entered. Furthermore, you have advantage 1 on any action rolls in which a familiarity with underground environments would prove helpful, such as attempts to identify the risk of a cave in or to find a secret passage within a cavern.
+While underground you may fail to find what you're looking for, but you can never be truly lost. You can always find your way back to the entrance through which you entered. Furthermore, you have advantage 1 on any action rolls in which a familiarity with underground environments would prove helpful, such as attempts to identify the risk of a cave in or to find a secret passage within a cavern.
 
 #### Street Rat
 
-You were raised on the streets or at least spent a good deal of time crawling about them. As such, you know how to navigate urban areas quickly, make yourself unseen, and find a bite to eat when you’re down on your luck. As one of the invisible urchins that crawl the city, you are also quite adept at picking up rumors in taverns and crowded streets.
+You were raised on the streets or at least spent a good deal of time crawling about them. As such, you know how to navigate urban areas quickly, make yourself unseen, and find a bite to eat when you're down on your luck. As one of the invisible urchins that crawl the city, you are also quite adept at picking up rumors in taverns and crowded streets.
 
 #### Vagabond
 
 Having spent significant time fending for yourself in the wilderness, you excel at surviving and navigating in the wild. You always know the direction of true north and you can automatically find enough food to feed yourself plus a number of additional people equal to your Learning attribute score.
 
-#### Warrior’s Code
+#### Warrior's Code
 
-As a veteran warrior, you command respect even from foes. Once per session, you can use this ability to cause an enemy or group of enemies to extend special concessions or favorable treatment toward you via an unspoken warrior’s code. The GM decides what these concessions look like. For example, your enemies might choose to trust you to come quietly and not shackle you, or overlook an insult that would have otherwise have been cause for bloodshed.
+As a veteran warrior, you command respect even from foes. Once per session, you can use this ability to cause an enemy or group of enemies to extend special concessions or favorable treatment toward you via an unspoken warrior's code. The GM decides what these concessions look like. For example, your enemies might choose to trust you to come quietly and not shackle you, or overlook an insult that would have otherwise have been cause for bloodshed.
 
 #### Whisperer of the Wild
 
@@ -584,15 +584,15 @@ Your live with your head in the clouds. You might just be ditzy, or maybe you ju
 
 #### Addiction
 
-The roll of the dice, the smoke of the Black Lotus, or the escape of the virtual reality machine. Whether your addiction is physical, mental, or social, the effect is generally the same: you’ve got an itch that you need to scratch, and you’ll sometimes do reckless or atrocious things to make sure that you can get your fix. You get to decide the nature and severity of your addiction.
+The roll of the dice, the smoke of the Black Lotus, or the escape of the virtual reality machine. Whether your addiction is physical, mental, or social, the effect is generally the same: you've got an itch that you need to scratch, and you'll sometimes do reckless or atrocious things to make sure that you can get your fix. You get to decide the nature and severity of your addiction.
 
 #### Ambitious
 
-You are willing to do anything to get ahead in life and often that means trampling upon other people on your way to the top. When presented with a situation requiring empathy for those beneath you, it’s typical for you to ignore their need. In addition, you may sometimes overreach in your attempts to get ahead, making bold and risky choices that can put you and those close to you in danger.
+You are willing to do anything to get ahead in life and often that means trampling upon other people on your way to the top. When presented with a situation requiring empathy for those beneath you, it's typical for you to ignore their need. In addition, you may sometimes overreach in your attempts to get ahead, making bold and risky choices that can put you and those close to you in danger.
 
 #### Bloodlust
 
-Battle isn’t just a way of life, it is *the* way of life. There isn’t a conflict you’ve encountered that wasn’t best solved with steel, and your allies will have a hard time convincing you otherwise. You are prone to starting fights when they aren’t necessary and prolonging them even after the enemy has surrendered.
+Battle isn't just a way of life, it is *the* way of life. There isn't a conflict you've encountered that wasn't best solved with steel, and your allies will have a hard time convincing you otherwise. You are prone to starting fights when they aren't necessary and prolonging them even after the enemy has surrendered.
 
 
 #### Brash
@@ -617,7 +617,7 @@ You have honed self-preservation into a way of life, and you will do almost anyt
 
 #### Dimwitted
 
-You aren’t the sharpest tack in the box. It’s not just that you weren’t gifted with skill in academia, it’s that you pick up on things pretty slowly overall. With the exception of your areas of expertise, you have a hard time learning new skills, following instructions, and maybe even remembering names.
+You aren't the sharpest tack in the box. It's not just that you weren't gifted with skill in academia, it's that you pick up on things pretty slowly overall. With the exception of your areas of expertise, you have a hard time learning new skills, following instructions, and maybe even remembering names.
 
 #### Disabled
 
@@ -625,22 +625,22 @@ You have some physical deficiency that holds you back in life. You decide the na
 
 #### Greedy
 
-You can’t help it: you just like things. Money, gems, items of power - they beckon you at every turn and you’ll often take great risks and maybe even betray your allies if the monetary reward is great enough. You’re easy to bribe, and you will often push the limits of negotiation or bartering in order to increase your share in the profits, even if it makes you a few enemies.
+You can't help it: you just like things. Money, gems, items of power - they beckon you at every turn and you'll often take great risks and maybe even betray your allies if the monetary reward is great enough. You're easy to bribe, and you will often push the limits of negotiation or bartering in order to increase your share in the profits, even if it makes you a few enemies.
 
 #### Honest
 
-You won’t tell a lie or engage in deceitful speech, even to save your own life or the life of another.
+You won't tell a lie or engage in deceitful speech, even to save your own life or the life of another.
 
 #### Hot Tempered
 Your fuse is short and your explosions are destructive. Sometimes your anger boils slowly over time and other times it erupts completely unexpectedly. But when you do fly off the handle, things rarely go well for you.
 
 #### Illiterate
 
-You can’t read or write, even in languages that you speak fluently.
+You can't read or write, even in languages that you speak fluently.
 
 #### Literal Minded
 
-You struggle with concepts and turns of phrase that are not literally true, such as idioms and metaphors. You might think sorcery is afoot if someone tells you it is “raining cats and dogs”. If a friend exaggerated by saying “I’d kill myself if Melzak were elected Supreme Justice”, you would be genuinely concerned for your friend’s life if Melzak did get elected.
+You struggle with concepts and turns of phrase that are not literally true, such as idioms and metaphors. You might think sorcery is afoot if someone tells you it is “raining cats and dogs”. If a friend exaggerated by saying “I'd kill myself if Melzak were elected Supreme Justice”, you would be genuinely concerned for your friend's life if Melzak did get elected.
 
 #### Mood Disorder
 
@@ -648,7 +648,7 @@ You suffer from a psychological condition that directly affects your mood, such 
 
 #### Naive
 
-Whether you are innocent, uninformed, or inexperienced, the results are the same: you are pretty gullible. You get to define the scope of your naivety. For example, maybe you’re a greenhorn from a big city on the east coast, so you are unlearned in the ways of the Wild West. Or maybe your memory was completely wiped out a few weeks ago and you are relearning the rules of civilization, thus your naivety presents itself much more universally.
+Whether you are innocent, uninformed, or inexperienced, the results are the same: you are pretty gullible. You get to define the scope of your naivety. For example, maybe you're a greenhorn from a big city on the east coast, so you are unlearned in the ways of the Wild West. Or maybe your memory was completely wiped out a few weeks ago and you are relearning the rules of civilization, thus your naivety presents itself much more universally.
 
 #### Overt
 
@@ -660,7 +660,7 @@ You are carrying a few extra pounds, and they tend to get in the way at all the 
 
 #### Pacifist
 
-You disdain combat and bloodshed of any kind, and will generally do whatever possible to avoid it. You can decide the extent of your pacifism. You might just revert to violence as a last resort, or you may be so averse to combat that you won’t lift a weapon even in defense of yourself or others.
+You disdain combat and bloodshed of any kind, and will generally do whatever possible to avoid it. You can decide the extent of your pacifism. You might just revert to violence as a last resort, or you may be so averse to combat that you won't lift a weapon even in defense of yourself or others.
 
 #### Phobia
 
@@ -668,7 +668,7 @@ You are terrified and incapable of rational thought when you are presented with 
 
 #### Proud
 
-Some call it an inflated ego. Others call it conceit. But you know that you really are just that good. The rabble are inferior, and you’re not afraid to let them know. Your pride may be a universal sense of self-worth, or it may only manifest itself within certain spheres or situations. For example, your rank in the Royal Star Force leads you to look down upon anyone trained in less illustrious armed forces.
+Some call it an inflated ego. Others call it conceit. But you know that you really are just that good. The rabble are inferior, and you're not afraid to let them know. Your pride may be a universal sense of self-worth, or it may only manifest itself within certain spheres or situations. For example, your rank in the Royal Star Force leads you to look down upon anyone trained in less illustrious armed forces.
 
 #### Psychotic
 
@@ -684,14 +684,14 @@ You suffer from some sort of chronic illness or condition, such as tuberculosis,
 
 #### Socially Awkward
 
-Something about your behavior tends to rub people the wrong way. Perhaps you don’t respect the personal space of others, you tend to ramble in conversation, or share overly personal details. Whatever the nature of your awkwardness, it makes social situations difficult for you at times.
+Something about your behavior tends to rub people the wrong way. Perhaps you don't respect the personal space of others, you tend to ramble in conversation, or share overly personal details. Whatever the nature of your awkwardness, it makes social situations difficult for you at times.
 
 #### Stubborn
-It’s your way or the highway. Maybe not all of the time, but once you’ve made your mind up on an important matter, you won’t budge. You probably won’t even compromise.
+It's your way or the highway. Maybe not all of the time, but once you've made your mind up on an important matter, you won't budge. You probably won't even compromise.
 
 #### Uncoordinated
 
-Your body just doesn’t work well with itself. You have trouble balancing, catching, throwing, and performing similar physical tasks that require dexterity or nimbleness.
+Your body just doesn't work well with itself. You have trouble balancing, catching, throwing, and performing similar physical tasks that require dexterity or nimbleness.
 
 #### Vengeful
 
@@ -704,24 +704,24 @@ You stand for a cause - whether it is a religion, a nation, a code, a way of lif
 
 ### Tell Your Story
 
-With your character created, you are all ready to start playing *Open Legend*. Whether you’re playing with old friends or complete strangers, and whether you’re completely new to roleplaying games or an experienced veteran, the following tips will help ensure a fun time for everyone at the table.
+With your character created, you are all ready to start playing *Open Legend*. Whether you're playing with old friends or complete strangers, and whether you're completely new to roleplaying games or an experienced veteran, the following tips will help ensure a fun time for everyone at the table.
 
 ### Relax
 
-*Open Legend* gives you a chance to step out of everyday life for a few hours and into a fantastical world where you can perform heroic deeds. Pour the Mountain Dew or grab a beer, order some takeout or pop open the pretzels--but whatever you do, shake the dice like your life depends on it and have fun. If you’re playing a dwarf, maybe pull out your best Scottish accent. If your character’s a witch, squint your eyes and speak in riddles. If you’re no expert thespian, think of other ways to add to the fun: play adventurous music on your phone, illustrate the party’s escapades, and so on.
+*Open Legend* gives you a chance to step out of everyday life for a few hours and into a fantastical world where you can perform heroic deeds. Pour the Mountain Dew or grab a beer, order some takeout or pop open the pretzels--but whatever you do, shake the dice like your life depends on it and have fun. If you're playing a dwarf, maybe pull out your best Scottish accent. If your character's a witch, squint your eyes and speak in riddles. If you're no expert thespian, think of other ways to add to the fun: play adventurous music on your phone, illustrate the party's escapades, and so on.
 
 ### Respect the GM
 
-If you’ve never GM’d before, you might not realize all the work that goes into it. More likely than not, your GM worked for hours to put their campaign together and prep for this session. Go with their storyline, overlook any accidental inconsistencies, and don’t cause a ruckus just for the sake of causing a ruckus. If there’s a dispute over the rules, accept the GM’s final ruling and agree to look it up later for the sake of the game.
+If you've never GM'd before, you might not realize all the work that goes into it. More likely than not, your GM worked for hours to put their campaign together and prep for this session. Go with their storyline, overlook any accidental inconsistencies, and don't cause a ruckus just for the sake of causing a ruckus. If there's a dispute over the rules, accept the GM's final ruling and agree to look it up later for the sake of the game.
 
 ### Respect the Other Players
 
-Different people play roleplaying games for different reasons. Some enjoy the tactical, chess-like combat encounters. Others just want to tell an epic story. Still others are born actors, reveling in every conversation with every character. Whatever it is that you enjoy about playing *Open Legend*, just remember that not everyone else at the table may enjoy the same aspects. Part of the GM’s duty is to give everyone a chance to shine, but you can do your part too by not hogging the spotlight and by encouraging the other players to have fun, whatever
+Different people play roleplaying games for different reasons. Some enjoy the tactical, chess-like combat encounters. Others just want to tell an epic story. Still others are born actors, reveling in every conversation with every character. Whatever it is that you enjoy about playing *Open Legend*, just remember that not everyone else at the table may enjoy the same aspects. Part of the GM's duty is to give everyone a chance to shine, but you can do your part too by not hogging the spotlight and by encouraging the other players to have fun, whatever
 that means for them.
 
 ## Gaining XP and Leveling Up
 
-As the legend you are creating unfolds and grows in danger and magnitude, your character’s power will grow to match the challenge. This power comes in the form of experience points (or XP), which are rewarded by the GM and allow you to advance in level and gain access to new feats, attributes, banes, and boons.
+As the legend you are creating unfolds and grows in danger and magnitude, your character's power will grow to match the challenge. This power comes in the form of experience points (or XP), which are rewarded by the GM and allow you to advance in level and gain access to new feats, attributes, banes, and boons.
 
 Your total XP earned determines your level, with every 3 XP allowing you to advance to the next level. Your level is used to determine your maximum attribute score as well as to provide a general indication of your power compared to other characters, NPCs, and monsters. Until you reach 5th level, the maximum attribute score is 5. From levels 6 to 9, the maximum is equal to your level.
 
@@ -777,4 +777,4 @@ See [*Feats*](http://www.openlegendrpg.com/feats) to view the complete list of f
 
 ### New Hit Points
 
-In Open Legend, attributes are the means by which your hit points increase. If you want your character to be able to take more hits, increase either your Fortitude, Presence, or Will attribute. As outlined in the default hit point formula, you’ll gain 2 hit points each time you raise any of those attributes by one.
+In Open Legend, attributes are the means by which your hit points increase. If you want your character to be able to take more hits, increase either your Fortitude, Presence, or Will attribute. As outlined in the default hit point formula, you'll gain 2 hit points each time you raise any of those attributes by one.

--- a/core/src/02-actions-attributes/01-chapter-two.md
+++ b/core/src/02-actions-attributes/01-chapter-two.md
@@ -6,7 +6,7 @@ interpret the results.
 ## When to Roll the Dice
 
 *Open Legend* is about creating great stories full of epic moments of heroism, and you roll dice to determine the outcome of those moments. In short, you only need to make action rolls when the outcome of the intended action plays a significant role in the story. In combat, for
-example, you’ll be making plenty of action rolls to clash blades, sling spells, shoot blasters, and leap over treacherous chasms. But you don’t need to roll a Persuasion check every time you go to buy something from the bazaar, and you don’t need to roll Logic to remember where you left your multi-pass.
+example, you'll be making plenty of action rolls to clash blades, sling spells, shoot blasters, and leap over treacherous chasms. But you don't need to roll a Persuasion check every time you go to buy something from the bazaar, and you don't need to roll Logic to remember where you left your multi-pass.
 
 *Open Legend* includes a number of Extraordinary attributes that can be used to represent futuristic theoretical science, magic, or inherent supernatural capabilities. For all other types of attribute, you can make an action roll with an attribute score of zero, but Extraordinary attributes require a minimum score of 1 in order to attempt a roll.
 
@@ -26,27 +26,27 @@ If you look back to the Core Mechanic, you can see that a simple failure is not 
 | If the action roll... | then the result is... |
 | :- | :- |
 | equals or exceeds the Challenge Rating, | the player succeeds. |
-| is less than the Challenge Rating, | the player succeeds with a twist. <br /> **- OR -** <br /> the player fails, but the story progresses. <br />*(GM’s Choice)* |
+| is less than the Challenge Rating, | the player succeeds with a twist. <br /> **- OR -** <br /> the player fails, but the story progresses. <br />*(GM's Choice)* |
 
-Here’s an example to illustrate how to make every roll matter.
+Here's an example to illustrate how to make every roll matter.
 
 *Pelias Quickenfit, a halfling burglar, is attempting to pick the lock on a door. He rolls an Agility check but gets lower than the challenge rating.*
 
 ### What NOT to do
 
-In this case, what might often happen at a gaming table is that upon seeing the halfling’s failure, another character immediately steps forward, say the barbarian, and attempts to force the door down. In *Open Legend*, such a reaction is frowned upon because it would mean that the burglar’s roll didn’t matter. It didn’t drive the story at all. Instead, the barbarian should wait for the GM to interpret the result of Pelias’s roll. Here are two potential outcomes for the roll:
+In this case, what might often happen at a gaming table is that upon seeing the halfling's failure, another character immediately steps forward, say the barbarian, and attempts to force the door down. In *Open Legend*, such a reaction is frowned upon because it would mean that the burglar's roll didn't matter. It didn't drive the story at all. Instead, the barbarian should wait for the GM to interpret the result of Pelias's roll. Here are two potential outcomes for the roll:
 
 *If the GM chooses **success with a twist**, they might rule that Pelias is able to open the lock; however, just as he finishes the job, he begins to hear a faint hissing sound from the door. A poison gas trap! The burglar immediately falls unconscious, and the rest of the party must decide what to do before the gas reaches them in a matter of seconds.*
 
-*If the GM chooses **failure, but the story progresses**, they might rule that although Pelias is unable to get the lock open, he hears footsteps approaching from around the corner accompanied by the familiar jingle of a jailer’s keychain. If the party can position themselves quickly enough, they may be able to get the keys without a fight.*
+*If the GM chooses **failure, but the story progresses**, they might rule that although Pelias is unable to get the lock open, he hears footsteps approaching from around the corner accompanied by the familiar jingle of a jailer's keychain. If the party can position themselves quickly enough, they may be able to get the keys without a fight.*
 
-Notice how both of these options allow Pelias’s action to drive the story forward just as much as a successful roll would have. In the second example, perhaps the barbarian still ends up bashing the door down with brute force, but at least the story moved on in some way because of the burglar’s attempts.
+Notice how both of these options allow Pelias's action to drive the story forward just as much as a successful roll would have. In the second example, perhaps the barbarian still ends up bashing the door down with brute force, but at least the story moved on in some way because of the burglar's attempts.
 
-The GM has a right to interpret the results of a failed action roll so that they can ensure that every roll matters. Players should make a special effort to avoid stepping on the GM’s toes in this regard.
+The GM has a right to interpret the results of a failed action roll so that they can ensure that every roll matters. Players should make a special effort to avoid stepping on the GM's toes in this regard.
 
 
 > ### Old Habits Die Hard
-> If you’ve played other RPGs in the past, you may be tempted to immediately follow another player’s failed roll with an action roll of your own.
+> If you've played other RPGs in the past, you may be tempted to immediately follow another player's failed roll with an action roll of your own.
 >
 > The following are common situations in which you should be especially vigilant to give the GM time to interpret the results of a failed action roll:
 >
@@ -57,11 +57,11 @@ The GM has a right to interpret the results of a failed action roll so that they
 
 ### Keep It Simple: Every Roll Matters for the GM
 
-The “every roll matters” rule was designed to make player actions meaningful to the story whether they succeed or fail. It recognizes the fact that static pass/fail checks aren’t particularly fun for players. But “every roll matters” also adds an extra layer of complexity to the game because it requires the GM to make on-the-fly interpretations.
+The “every roll matters” rule was designed to make player actions meaningful to the story whether they succeed or fail. It recognizes the fact that static pass/fail checks aren't particularly fun for players. But “every roll matters” also adds an extra layer of complexity to the game because it requires the GM to make on-the-fly interpretations.
 
 **So when the GM makes a roll**, a success is a success and a failure is a failure.
 
-This is for the sake of simplicity and fun. When a player fails a roll, it’s not very fun if something doesn’t come out of it. When the GM fails a roll, though, there is usually much rejoicing at the table.
+This is for the sake of simplicity and fun. When a player fails a roll, it's not very fun if something doesn't come out of it. When the GM fails a roll, though, there is usually much rejoicing at the table.
 
 ### Group Action Rolls
 
@@ -71,23 +71,23 @@ The GM always has the final say as to when a group action roll is called for and
 
 ## Interpreting Action Rolls
 
-The previous example provides just one method in which a GM might interpret the results of an action roll, but there is a little more to it than that. In this section, you’ll get some empowering guidelines to help everyone at the table feel comfortable with the amount of improvisation required for *Open Legend*.
+The previous example provides just one method in which a GM might interpret the results of an action roll, but there is a little more to it than that. In this section, you'll get some empowering guidelines to help everyone at the table feel comfortable with the amount of improvisation required for *Open Legend*.
 
 ### Interpreting Success
 
-A successful action roll is by far the easiest to interpret: it means that the player gets what they were hoping for. If they were rolling to climb a cliff, then they climb it. If they were trying to pick a pocket, then it’s picked. If they were trying to stab an orc, it is stabbed. And so on.
+A successful action roll is by far the easiest to interpret: it means that the player gets what they were hoping for. If they were rolling to climb a cliff, then they climb it. If they were trying to pick a pocket, then it's picked. If they were trying to stab an orc, it is stabbed. And so on.
 
 In some cases, the results of a success are already written into the rules (such as in combat, explained in Chapter 6). Often, though, the GM will need to determine what happens with a successful action roll.
 
 There are two primary factors to consider when adjudicating a success:
 
-**Don’t roll if there’s nothing to succeed at.** For example, if a character wants to search a corridor for secret passages, but the GM knows there aren’t any, they don't need to have the character roll a Perception check, because there’s nothing to find; the roll doesn’t matter.
+**Don't roll if there's nothing to succeed at.** For example, if a character wants to search a corridor for secret passages, but the GM knows there aren't any, they don't need to have the character roll a Perception check, because there's nothing to find; the roll doesn't matter.
 
-**Describe your success.** Whenever the situation allows, the player should show the rest of the table what success looks like. It’s their turn in the spotlight, so let them shine. If your rogue successfully disarms a trap, describe how the scything blade just barely nicked your cheek before you finished the job. If your mech knight makes a successful leap attack against an enemy tank, narrate how you use the extra momentum provided by the leap to dig your servo-blades through the tank's hull. Sometimes, of course, the GM has privileged information, so they need to be the one to describe things. Whenever possible, though, the players should describe their own success.
+**Describe your success.** Whenever the situation allows, the player should show the rest of the table what success looks like. It's their turn in the spotlight, so let them shine. If your rogue successfully disarms a trap, describe how the scything blade just barely nicked your cheek before you finished the job. If your mech knight makes a successful leap attack against an enemy tank, narrate how you use the extra momentum provided by the leap to dig your servo-blades through the tank's hull. Sometimes, of course, the GM has privileged information, so they need to be the one to describe things. Whenever possible, though, the players should describe their own success.
 
 ### Interpreting Success with a Twist
 
-When a player fails an action roll, the GM may choose to allow the player’s action to succeed with a twist. In this case, the player gets what they wanted originally, but there is some sort of unintended consequence or unexpected cost. The following list is not exhaustive, but it should give you a pretty good idea of what qualifies as a twist.
+When a player fails an action roll, the GM may choose to allow the player's action to succeed with a twist. In this case, the player gets what they wanted originally, but there is some sort of unintended consequence or unexpected cost. The following list is not exhaustive, but it should give you a pretty good idea of what qualifies as a twist.
 
 - **Put a character in danger**
 - **Expend a resource**
@@ -95,29 +95,29 @@ When a player fails an action roll, the GM may choose to allow the player’s ac
 - **Overlook an important detail**
 - **Waste time**
 - **Attract attention**
-- **Find something you weren’t looking for**
+- **Find something you weren't looking for**
 
-The important thing to realize is that a success with a twist is still a success. It just comes at some sort of a cost: You find the trail of the hydra you’re tracking, but it leads you through a swamp infested with undead. You sense that the merchant is overcharging you, but you fail to realize that he’s also distracting you from the thugs sneaking up behind you. You are able to land a shot against the zombie, but it costs you the last bullet in your magazine.
+The important thing to realize is that a success with a twist is still a success. It just comes at some sort of a cost: You find the trail of the hydra you're tracking, but it leads you through a swamp infested with undead. You sense that the merchant is overcharging you, but you fail to realize that he's also distracting you from the thugs sneaking up behind you. You are able to land a shot against the zombie, but it costs you the last bullet in your magazine.
 
 ### Interpreting Failure, but the Story Progresses
 
-In *Open Legend*, a failure is never just a failure, it’s always an important element in the story, hence the rule that “the story progresses”.
+In *Open Legend*, a failure is never just a failure, it's always an important element in the story, hence the rule that “the story progresses”.
 
 Progress, though, can mean a lot of things. When the GM selects this option, the following interpretations should give you some idea of how the story can progress in spite of failure.
 
 **The player finds an opportunity for success.** Even though your magic fails to dispel the curse afflicting your ally, you discover during later study that a rare herb growing in a nearby forest would give you the power you require.
 
-**The danger snowballs.** You fail to jump a chasm while fleeing a band of cannibals. You fall along the cliffside, taking some damage. When you gather your senses, you realize that you aren’t only separated from the rest of your party, but you’ve also fallen into the nest of a Roc.
+**The danger snowballs.** You fail to jump a chasm while fleeing a band of cannibals. You fall along the cliffside, taking some damage. When you gather your senses, you realize that you aren't only separated from the rest of your party, but you've also fallen into the nest of a Roc.
 
-**The information is false.** You think you’ve got a good read on the mayor during your negotiations. It seems like she's completely in favor of your plan to negotiate an alliance among the neighboring survivor settlements. When you set out the next day, however, it turns out you were wrong, and the guards the mayor sent to ensure your safe passage turn out to be your assassins.
+**The information is false.** You think you've got a good read on the mayor during your negotiations. It seems like she's completely in favor of your plan to negotiate an alliance among the neighboring survivor settlements. When you set out the next day, however, it turns out you were wrong, and the guards the mayor sent to ensure your safe passage turn out to be your assassins.
 
-The GM gets to decide how bad a failed action roll turns out to be, and sometimes, it’s really bad. While some of these examples are harsher than others, they all share one common factor: they steer the narrative forward. Failure is never just a failure.
+The GM gets to decide how bad a failed action roll turns out to be, and sometimes, it's really bad. While some of these examples are harsher than others, they all share one common factor: they steer the narrative forward. Failure is never just a failure.
 
 ## Determining Challenge Rating
 
-Many actions that you will undertake in *Open Legend* have a Challenge Rating (CR) that is determined by the rules. Attacks in combat, for example, use one of the target’s defense scores as the CR.
+Many actions that you will undertake in *Open Legend* have a Challenge Rating (CR) that is determined by the rules. Attacks in combat, for example, use one of the target's defense scores as the CR.
 
-Oftentimes, though, the GM will need to determine the CR for actions that aren’t spelled out clearly in the rules. In these cases, the GM can use the Challenge Ratings by Difficulty Table to set an appropriate CR.
+Oftentimes, though, the GM will need to determine the CR for actions that aren't spelled out clearly in the rules. In these cases, the GM can use the Challenge Ratings by Difficulty Table to set an appropriate CR.
 
 <div class="table-no-body"></div>
 | Challenge Ratings by Difficulty |
@@ -126,19 +126,19 @@ Oftentimes, though, the GM will need to determine the CR for actions that aren�
 
 | Difficulty | Challenge Rating | Example Actions |
 | :-: | :-: | :------ |
-| Everyday | 10 | leap a 5’ gap, climb a surface with ledges, break down a household door, haggle a simple merchant for a discount |
+| Everyday | 10 | leap a 5' gap, climb a surface with ledges, break down a household door, haggle a simple merchant for a discount |
 | Challenging | 15 | climb a rough surface, catch the drift of a text in an unfamiliar language, break down a strong wooden door |
-| Heroic | 20 | climb a smooth surface, leap a 15’ gap, translate a text in an unfamiliar language, convince a neutral party to take a risk for you |
+| Heroic | 20 | climb a smooth surface, leap a 15' gap, translate a text in an unfamiliar language, convince a neutral party to take a risk for you |
 | Epic | 25 | translate a text in an alien language, break down an iron door |
-| Legendary | 30 | leap a 25’ chasm, climb a flat surface, befriend an enemy with a vendetta against you |
+| Legendary | 30 | leap a 25' chasm, climb a flat surface, befriend an enemy with a vendetta against you |
 
-It’s important to note that Challenge Ratings are not typically set to be relative to the party’s level. So, breaking down a strong wooden door is CR 15 whether the party is first level or tenth.
+It's important to note that Challenge Ratings are not typically set to be relative to the party's level. So, breaking down a strong wooden door is CR 15 whether the party is first level or tenth.
 
 ### Contested Actions
 
 Sometimes, two or more characters are directly opposing each other in a test of strength, wits, or charm. For example, a mighty barbarian wrestles with a minotaur to get hold of a magical gem. Or three representatives of different star systems attempt to persuade the warleader of the intergalactic reavers to join their forces. Or a stealthy ninja attempts to sneak unseen past the watch of the monks on guard. These sorts of situations are called **contested actions**.
 
-To resolve such contests, each character involved makes an action roll using an appropriate attribute. Whoever rolls the highest succeeds at the action. Sometimes, all parties use the same attribute for their action rolls, but often, each character will use a different attribute, as in the case of the rogue attempting to sneak (Agility) past the guard’s watch (Perception).
+To resolve such contests, each character involved makes an action roll using an appropriate attribute. Whoever rolls the highest succeeds at the action. Sometimes, all parties use the same attribute for their action rolls, but often, each character will use a different attribute, as in the case of the rogue attempting to sneak (Agility) past the guard's watch (Perception).
 
 > #### Example Contested Action
 >
@@ -146,7 +146,7 @@ To resolve such contests, each character involved makes an action roll using an 
 
 ## Advantage and Disadvantage
 
-Sometimes, you will attempt an action under circumstances that give you a significant upper hand, such as when attacking an enemy from behind. Other times, you’ll be working against exceptional hindrances, such as when trying to climb a rope that an enemy has covered in grease. In these types of cases, instead of adjusting the Challenge Rating of the task, the GM should assign your roll either **advantage** or **disadvantage**.
+Sometimes, you will attempt an action under circumstances that give you a significant upper hand, such as when attacking an enemy from behind. Other times, you'll be working against exceptional hindrances, such as when trying to climb a rope that an enemy has covered in grease. In these types of cases, instead of adjusting the Challenge Rating of the task, the GM should assign your roll either **advantage** or **disadvantage**.
 
 Advantage and disadvantage are always expressed with a numeric level, such as “advantage 1” or “disadvantage 3”. Multiple instances of advantage and disadvantage can add together, so if you have advantage 1 on an attack because you are flanking a foe, and you also possess a feat that grants you advantage 1, you have a total of advantage 2.
 
@@ -164,7 +164,7 @@ Disadvantage works in a similar manner. When you have disadvantage, you still ro
 
 > #### Example of Disadvantage
 >
-> Armand attempts to blast his foe with psychokinetic fire. However, he is currently being distracted by a smoke bomb hurled by an enemy soldier, granting him disadvantage 1. Furthermore, he has also been subject to the *fatigued* bane, adding on an additional disadvantage 1. Armand’s Energy score is 5, granting him 2d6 attribute dice. He rolls 1d20 + 4d6. After rolling, but before calculating his total, he removes the two highest rolling d6s.
+> Armand attempts to blast his foe with psychokinetic fire. However, he is currently being distracted by a smoke bomb hurled by an enemy soldier, granting him disadvantage 1. Furthermore, he has also been subject to the *fatigued* bane, adding on an additional disadvantage 1. Armand's Energy score is 5, granting him 2d6 attribute dice. He rolls 1d20 + 4d6. After rolling, but before calculating his total, he removes the two highest rolling d6s.
 
 ### Advantage and Disadvantage Are Only Applied BEFORE Explosions
 
@@ -225,7 +225,7 @@ Characters begin play with zero legend points, and the maximum they may acquire 
 
 > ### Example of Earning a Legend Point
 >
-> Zaax has the *hot tempered* flaw, causing him to easily lose control of his anger. In the middle of the party’s tense negotiations with the Imperial Guard, Zaax loses his patience with the high commander and shoots one of the guardsmen. This is a clear example of Zaax roleplaying his flaw despite negative consequences, so the GM awards him with a legend point.
+> Zaax has the *hot tempered* flaw, causing him to easily lose control of his anger. In the middle of the party's tense negotiations with the Imperial Guard, Zaax loses his patience with the high commander and shoots one of the guardsmen. This is a clear example of Zaax roleplaying his flaw despite negative consequences, so the GM awards him with a legend point.
 
 The GM may also feel free to establish other rules for awarding legend points. For example, some GMs like to allow each player to award another PC one legend point each session. Other tables might have a vote for MVP or best roleplayer at the end of each session, with the winner gaining a legend point.
 
@@ -235,11 +235,11 @@ Before making an action roll, a PC may spend a maximum number of legend points e
 
 ## Attributes and Action Rolls in Play
 
-As previously explained, whenever you need to determine the outcome of a meaningful task, you make an action roll using an attribute appropriate to the task. Sometimes, the results of your roll will be very clearly spelled out in the rules, such as when making attacks or invoking banes and boons. Oftentimes, though, you’ll want to attempt an action that isn’t spelled out explicitly in the rules. In this section, you’ll find examples of the sorts of actions you can accomplish with every attribute, as well as some suggested interpretations of “success with a twist” and “failure, but the story progresses” for those times when the dice just don’t go your way. 
+As previously explained, whenever you need to determine the outcome of a meaningful task, you make an action roll using an attribute appropriate to the task. Sometimes, the results of your roll will be very clearly spelled out in the rules, such as when making attacks or invoking banes and boons. Oftentimes, though, you'll want to attempt an action that isn't spelled out explicitly in the rules. In this section, you'll find examples of the sorts of actions you can accomplish with every attribute, as well as some suggested interpretations of “success with a twist” and “failure, but the story progresses” for those times when the dice just don't go your way. 
 
 For each attribute, we offer examples of actions classified at three levels based on difficulty and extent of impact on the narrative:
 
-**Challenging (CR 15):** Success at the task indicates overcoming a minor challenge or altering the narrative in a way that isn’t disruptive.
+**Challenging (CR 15):** Success at the task indicates overcoming a minor challenge or altering the narrative in a way that isn't disruptive.
 
 **Heroic (CR 20):** Success at the task indicates overcoming a major challenge or altering the narrative in a mildly disruptive way.
 
@@ -275,19 +275,19 @@ While his party is busy strategizing about back doors, secret passages, and disg
 
 ### Agility
 
-Agility is a measure of your character’s dexterity, nimbleness, motor skills, and reaction time. It governs tasks such as remaining unseen, swinging from chandeliers, maneuvering in a dogfight, and picking a lock.
+Agility is a measure of your character's dexterity, nimbleness, motor skills, and reaction time. It governs tasks such as remaining unseen, swinging from chandeliers, maneuvering in a dogfight, and picking a lock.
 
 #### Challenging Test of Agility (CR 15)
 
 As Terri chases Gizmo the Gnomtorious bounty hunter through the narrow corridors of the space station, her quarry releases his patented Slip Slime Bomb, covering the ground between them with a slippery greenish grease. Terri attempts to slide nimbly through the slime instead of letting it slow her down.
 
-**Success with a twist:** Terri glides gracefully across the grease, but fails to notice the broken exhaust pipe hanging from the ceiling until the last minute. She manages to dodge the pipe only by grabbing hold of it and swinging around it, which forces her to drop her shotgun. If she’s going to keep up with Gizmo, she’ll have to do it unarmed.
+**Success with a twist:** Terri glides gracefully across the grease, but fails to notice the broken exhaust pipe hanging from the ceiling until the last minute. She manages to dodge the pipe only by grabbing hold of it and swinging around it, which forces her to drop her shotgun. If she's going to keep up with Gizmo, she'll have to do it unarmed.
 
-**Failure, but the story progresses:** With all the grace and agility of a drunken elephant, Terri falls on her face in a pile of green goo. By the time she struggles to the other edge of the slime, Gizmo is nowhere in sight, and she’ll have to think fast to decide which direction to take at the T-intersection up ahead if she doesn’t want to lose her quarry.
+**Failure, but the story progresses:** With all the grace and agility of a drunken elephant, Terri falls on her face in a pile of green goo. By the time she struggles to the other edge of the slime, Gizmo is nowhere in sight, and she'll have to think fast to decide which direction to take at the T-intersection up ahead if she doesn't want to lose her quarry.
 
 #### Heroic Test of Agility (CR 20)
 
-Jax is piloting his one man Beta Flier in a high speed dogfight against a pair of Dalturian Destroyers. They’re both on his tail, and if he doesn’t shake them soon, they’ll have locked on their homing missiles. Jax slams the throttle forward and attempts to speed through a narrow canyon up ahead.
+Jax is piloting his one man Beta Flier in a high speed dogfight against a pair of Dalturian Destroyers. They're both on his tail, and if he doesn't shake them soon, they'll have locked on their homing missiles. Jax slams the throttle forward and attempts to speed through a narrow canyon up ahead.
 
 **Success with a twist:** Jax zooms through the rocky terrain at breakneck speed. When he comes out the other end, he has managed to lose one of the Dalturians, but the second is still hot on his trail.
 
@@ -297,7 +297,7 @@ Jax is piloting his one man Beta Flier in a high speed dogfight against a pair o
 
 Winston, renowned as the finest archer in the land, has been captured by the giant lord Glorrg. Glorrg demands that Winston proves he really is who he says he is. The giant has one of his servants release four hummingbirds in the air and demands Winston to shoot them all down before they can escape.
 
-**Success with a twist:** In his signature style, Winston knocks 4 arrows at once and lets them fly. All four birds fall to the ground. However, the archer was not completely aware of his surroundings, and one of the arrows skewers one of Glorrg’s servants, sending the giant lord into a fit of rage.
+**Success with a twist:** In his signature style, Winston knocks 4 arrows at once and lets them fly. All four birds fall to the ground. However, the archer was not completely aware of his surroundings, and one of the arrows skewers one of Glorrg's servants, sending the giant lord into a fit of rage.
 
 **Failure, but the story progresses:** Winston fires arrow after arrow, but he can only manage to fell three of the birds. Glorrg is not impressed, and he orders the archer to be stripped of his bow and thrown into the Pit of Beasts.
 
@@ -311,13 +311,13 @@ Sheriff Bates and his posse of deputies are tracking a pair of bandits through t
 
 **Success with a twist:** Those who fail their roll are able to keep up with the rest of the crew, but they suffer one level of the *fatigued* bane.
 
-**Failure, but the story progresses:** Everyone who fails simply cannot keep up. If they don’t rest, they will assuredly pass out. The posse must make a tough decision: make camp and risk the bandits escaping, or split up the party to let the hardier members cover ground.
+**Failure, but the story progresses:** Everyone who fails simply cannot keep up. If they don't rest, they will assuredly pass out. The posse must make a tough decision: make camp and risk the bandits escaping, or split up the party to let the hardier members cover ground.
 
 #### Heroic Test of Fortitude (CR 20)
 
-While traversing the deep reaches of space, Spaz was unfortunately infected with the Chronos Plague - a debilitating disease that distorts the infected’s perception of space-time. He lies in the Rebel HQ sick bay, struggling to fight off the illness.
+While traversing the deep reaches of space, Spaz was unfortunately infected with the Chronos Plague - a debilitating disease that distorts the infected's perception of space-time. He lies in the Rebel HQ sick bay, struggling to fight off the illness.
 
-**Success with a twist:** Spaz’s immune system is too compromised, and the disease persists. However, while Spaz was confined to the sick bay, his ally Dr. Vreck was hard at work researching a potential cure. Vreck has learned of a rare subthermal lichen that grows only on the asteroids of the Alpha System. This lichen may hold the secret to reversing the disease.
+**Success with a twist:** Spaz's immune system is too compromised, and the disease persists. However, while Spaz was confined to the sick bay, his ally Dr. Vreck was hard at work researching a potential cure. Vreck has learned of a rare subthermal lichen that grows only on the asteroids of the Alpha System. This lichen may hold the secret to reversing the disease.
 
 **Failure, but the story progresses:** Spaz cannot shake the Chronos Plague, and like all victims who fail to fight it off in the first week, the symptoms become permanent. Barring some miraculous cure, Spaz will forever suffer from periodic bouts of space-time distortion. He gains a new custom flaw: Chronos Plague.
 
@@ -331,7 +331,7 @@ A party of legendary heroes has followed the Shadow Demon Yrrllx to his native h
 
 ### Learning
 
-Learning is the attribute of raw knowledge, memory, and the ability to apply the right facts in the right situation. You make a learning roll whenever you attempt to recall important information, make sense of conflicting details, or assimilate unfamiliar knowledge into your own context. An important note about learning is that it represents both your character’s understanding of the knowledge that she is familiar with and also her ability to gain new knowledge quickly. So, a foreigner in a strange land wouldn’t be able to recall facts about local history just because she has a high learning score. However, her high learning score would be of use when it comes to quickly assimilating the lore of her new environment.
+Learning is the attribute of raw knowledge, memory, and the ability to apply the right facts in the right situation. You make a learning roll whenever you attempt to recall important information, make sense of conflicting details, or assimilate unfamiliar knowledge into your own context. An important note about learning is that it represents both your character's understanding of the knowledge that she is familiar with and also her ability to gain new knowledge quickly. So, a foreigner in a strange land wouldn't be able to recall facts about local history just because she has a high learning score. However, her high learning score would be of use when it comes to quickly assimilating the lore of her new environment.
 
 #### Challenging Test of Learning (CR 15)
 
@@ -359,35 +359,35 @@ Belmont the Bard is attempting to negotiate peace between two gnoll tribes that 
 
 ### Logic
 
-Logic is the mental attribute of deductive reasoning and problem solving. Characters who are skilled in logic might be riddle masters, expert programmers, military geniuses, uncanny sleuths, or ingenious trap smiths. The GM will call for a logic roll when you attempt to decipher a mystery, predict an opponent’s behavior, or devise a foolproof plan.
+Logic is the mental attribute of deductive reasoning and problem solving. Characters who are skilled in logic might be riddle masters, expert programmers, military geniuses, uncanny sleuths, or ingenious trap smiths. The GM will call for a logic roll when you attempt to decipher a mystery, predict an opponent's behavior, or devise a foolproof plan.
 
 #### Challenging Test of Logic (CR 15)
 
-Commander Zack’s sky ship, The Danger,  is under attack by a half dozen enemy gliders. The gliders can turn on a dime and easily outmaneuver The Danger’s powerful gatling guns at the bow. Zack takes a moment to analyze their attack formation and predict the gliders’ most probable movements in hopes of catching as many of them as possible at the front of his ship during the next run.
+Commander Zack's sky ship, The Danger,  is under attack by a half dozen enemy gliders. The gliders can turn on a dime and easily outmaneuver The Danger's powerful gatling guns at the bow. Zack takes a moment to analyze their attack formation and predict the gliders' most probable movements in hopes of catching as many of them as possible at the front of his ship during the next run.
 
-**Success with a twist:** Zack’s experience pays off, and he is able to issue his crew commands to catch three of the gliders within range of the gatling guns. However, the turn leaves him in vulnerable position to the other three gliders, who receive advantage on their attacks this round.
+**Success with a twist:** Zack's experience pays off, and he is able to issue his crew commands to catch three of the gliders within range of the gatling guns. However, the turn leaves him in vulnerable position to the other three gliders, who receive advantage on their attacks this round.
 
-**Failure, but the story progresses:** Zack thinks he’s got the gliders right where he wants them, but his crew is slow to take orders, and the gliders manage to completely avoid the gatling guns this round.
+**Failure, but the story progresses:** Zack thinks he's got the gliders right where he wants them, but his crew is slow to take orders, and the gliders manage to completely avoid the gatling guns this round.
 
 #### Heroic Test of Logic (CR 20)
 
-Cyril the android is stranded in Junkland, a miles long island of debris that floats in the ocean outside of New L.A. Cyril’s core battery has been severely damaged, making his CPU process at half speed. The android scavenges through the hills of Junkland for enough spare parts to jerry-rig a temporary repair.
+Cyril the android is stranded in Junkland, a miles long island of debris that floats in the ocean outside of New L.A. Cyril's core battery has been severely damaged, making his CPU process at half speed. The android scavenges through the hills of Junkland for enough spare parts to jerry-rig a temporary repair.
 
 **Success with a twist:** Cyril finds what he needs to repair his battery, but the materials are unstable. The GM rules that until Cyril can find appropriate materials, he will suffer the *stunned* bane every time he rolls a 5 or less on the d20 for an action roll.
 
-**Failure, but the story progresses:** Cyril can’t find anything salvageable from the junk heaps nearby. What he does manage to stir up, however, are a pair of Techno Pack Rats who eye his circuitry and armored plating with much envy.
+**Failure, but the story progresses:** Cyril can't find anything salvageable from the junk heaps nearby. What he does manage to stir up, however, are a pair of Techno Pack Rats who eye his circuitry and armored plating with much envy.
 
 #### Epic Test of Logic (CR 25)
 
-Azure and party are attempting to negotiate with the Dragon Council in order to convince the wyrms to break their vow of neutrality and aid the races of good in the Demon War. Things are looking grim, but Azure is well-studied in the Dragon Code, and he attempts to find a loophole around the Council’s insistence that the Law of Gold requires that any dragon who serves the lower races must be paid its weight in gold for the service. The legalistic wyrms insist that even if any of their kin were willing to fight along the humanoids out of the goodness of their hearts, the Law of Gold would still need to be satisfied.
+Azure and party are attempting to negotiate with the Dragon Council in order to convince the wyrms to break their vow of neutrality and aid the races of good in the Demon War. Things are looking grim, but Azure is well-studied in the Dragon Code, and he attempts to find a loophole around the Council's insistence that the Law of Gold requires that any dragon who serves the lower races must be paid its weight in gold for the service. The legalistic wyrms insist that even if any of their kin were willing to fight along the humanoids out of the goodness of their hearts, the Law of Gold would still need to be satisfied.
 
-**Success with a twist:** Azure notes to the Council that if the payment were to take place on the plane of Chaos, where weights and measures shift unpredictably, then the humanoids could readily provide enough gold to satisfy the law provided the exchange occur at the proper moment. Although much of the Council is dissatisfied with this proposition, they bring it to a vote and favor falls on Azure’s side. However, for the inconvenience of interdimensional travel, the Council rules that every wyrm employed must also be compensated with a magical artifact of acceptable power.
+**Success with a twist:** Azure notes to the Council that if the payment were to take place on the plane of Chaos, where weights and measures shift unpredictably, then the humanoids could readily provide enough gold to satisfy the law provided the exchange occur at the proper moment. Although much of the Council is dissatisfied with this proposition, they bring it to a vote and favor falls on Azure's side. However, for the inconvenience of interdimensional travel, the Council rules that every wyrm employed must also be compensated with a magical artifact of acceptable power.
 
 **Failure, but the story progresses:** Azure fails to come up with a reasonable loophole, and the Council rules that any wyrm who aids in the Demon Wars without the Law of Gold being satisfied will be deemed an outcast of dragonkind.
 
 ### Perception
 
-Perception governs your ability notice important details in people, places, and things. You roll perception when you are trying to find a secret passage, follow a trail, sense ulterior motives, or spot a hidden foe. For perception rolls especially, it’s important to remember that *every roll matters*. The GM should only ask for a perception roll when there is actually something to be perceived. Furthermore, the GM should ask for the roll only at the moment when the outcome matters. So, if a rogue enters a dungeon and declares that he will be searching for traps in every room, the player should not actually roll until he might actually discover a trap. That way, the outcome of the roll will actually matter.
+Perception governs your ability notice important details in people, places, and things. You roll perception when you are trying to find a secret passage, follow a trail, sense ulterior motives, or spot a hidden foe. For perception rolls especially, it's important to remember that *every roll matters*. The GM should only ask for a perception roll when there is actually something to be perceived. Furthermore, the GM should ask for the roll only at the moment when the outcome matters. So, if a rogue enters a dungeon and declares that he will be searching for traps in every room, the player should not actually roll until he might actually discover a trap. That way, the outcome of the roll will actually matter.
 
 #### Challenging Test of Perception (DC 15)
 
@@ -411,23 +411,23 @@ Therilas attempts to track a pixie through the Fey Wood. The trail is two days o
 
 **Success with a twist:** Therilas loses the trail a mile into the woods. As he searches about in frustration, he is approached by a sentient fox who offers to reveal the location of the pixie… for a price.
 
-**Failure, but the story progresses:** Therilas wanders for hours in the Fey Wood trying to pick up the trail. Finally, he finds it, though it seems oddly fresh. Too late does he realize that he has been tricked, and the pixie has led him into a trap. He finds himself surrounded by denizens of the Fey Wood and hears the pixie’s mischievous laughter from the canopy above.
+**Failure, but the story progresses:** Therilas wanders for hours in the Fey Wood trying to pick up the trail. Finally, he finds it, though it seems oddly fresh. Too late does he realize that he has been tricked, and the pixie has led him into a trap. He finds himself surrounded by denizens of the Fey Wood and hears the pixie's mischievous laughter from the canopy above.
 
 ### Will
 
-Will is the attribute of mental fortitude and willpower. It represents your character’s ability to fight back against threats to their sanity, bravery, or focus. While your Will often plays a passive role by contributing to your Resolve defense score, you will also make active tests with this attribute when you are calling solely on your willpower to overcome a mental threat or directly pitting your Will against an outside force, as in the following examples.
+Will is the attribute of mental fortitude and willpower. It represents your character's ability to fight back against threats to their sanity, bravery, or focus. While your Will often plays a passive role by contributing to your Resolve defense score, you will also make active tests with this attribute when you are calling solely on your willpower to overcome a mental threat or directly pitting your Will against an outside force, as in the following examples.
 
 #### Challenging Test of Will (CR 15)
 
-Setting Sun and his companions are lost in the desert. They’ve been without food and water for 2 days, and the GM asks what each of them are doing to stave off the negative effects of dehydration and starvation. While the monk’s allies call upon their Fortitude to grit their teeth through the pain or their Alteration magic to bolster their bodies, Setting Sun retreats into the calm of his meditative mind, relying on his Will to get him through the trial.
+Setting Sun and his companions are lost in the desert. They've been without food and water for 2 days, and the GM asks what each of them are doing to stave off the negative effects of dehydration and starvation. While the monk's allies call upon their Fortitude to grit their teeth through the pain or their Alteration magic to bolster their bodies, Setting Sun retreats into the calm of his meditative mind, relying on his Will to get him through the trial.
 
-**Success with a twist:** The monk’s meditation works to an extent. He is only able to stave off his hunger, but not his thirst, so he suffers one level of the *fatigued* bane.
+**Success with a twist:** The monk's meditation works to an extent. He is only able to stave off his hunger, but not his thirst, so he suffers one level of the *fatigued* bane.
 
-**Failure, but the story progresses:** Setting Sun’s training was good, but the calm of the monastery is hard to recall amidst his current struggles. OVercome with hunger and thirst, the monk suffers 2 levels of the *fatigued* bane.
+**Failure, but the story progresses:** Setting Sun's training was good, but the calm of the monastery is hard to recall amidst his current struggles. OVercome with hunger and thirst, the monk suffers 2 levels of the *fatigued* bane.
 
 #### Heroic Test of Will (CR 20)
 
-Deep in the lower chambers of Overhill Asylum, the investigators discover an ancient and alien evil whose very existence in the physical dimension seems an impossibility. Unable to reconcile their understanding of the laws of nature with the creature’s writhing form and material instability, the PCs begin to lose touch with reality. The GM calls for each investigator to make a Will roll.
+Deep in the lower chambers of Overhill Asylum, the investigators discover an ancient and alien evil whose very existence in the physical dimension seems an impossibility. Unable to reconcile their understanding of the laws of nature with the creature's writhing form and material instability, the PCs begin to lose touch with reality. The GM calls for each investigator to make a Will roll.
 
 **Success with a twist:** The PCs are overcome with an uncontrollable but temporary horror. While they remain in the Asylum, they suffer a special form of the *demoralized* bane (Power Level 3). It can not be resisted until they leave the Asylum
 
@@ -437,9 +437,9 @@ Deep in the lower chambers of Overhill Asylum, the investigators discover an anc
 
 While jacked deep into the Network, Snitch encounters a data file that has been encrypted by Prime, who is said to be the first Jacker to find a way to enter the Network. Prime detects the intrusion, but the overzealous Snitch chooses to go head to head with the legend rather than jack out. Snitch puts the full power of his Will against Prime in hopes of breaking through his firewall.
 
-**Success with a twist:** Snitch actually manages to find a way to break through Prime’s guard and access some of his data. However, the oldest Jacker in the Network is no pushover. During the battle of wits he discovers a leak in Snitch’s security systems. When Snitch jacks out, he discovers that his bank account has been emptied of every single credit he owned.
+**Success with a twist:** Snitch actually manages to find a way to break through Prime's guard and access some of his data. However, the oldest Jacker in the Network is no pushover. During the battle of wits he discovers a leak in Snitch's security systems. When Snitch jacks out, he discovers that his bank account has been emptied of every single credit he owned.
 
-**Failure, but the story progresses:** Snitch’s Will is no match for the first Jacker. Prime protects his data and ejects Snitch from the Network.
+**Failure, but the story progresses:** Snitch's Will is no match for the first Jacker. Prime protects his data and ejects Snitch from the Network.
 
 ### Deception
 
@@ -451,23 +451,23 @@ Slade has acquired an appropriate disguise to pass as a city guard. As he attemp
 
 **Success with a twist:** Slade does really well at keeping up his disguise, but he fails to address a superior officer appropriately at one point. Although he will gain access to the armory, this officer remembers the altercation and will be able to identify Slade at a later time if suspicion is ever raised.
 
-**Failure, but the story progresses:** Slade’s military etiquette faux pas is worse than expected. The offended officer immediately requests Slade’s commanding officer so that he can report the offense.
+**Failure, but the story progresses:** Slade's military etiquette faux pas is worse than expected. The offended officer immediately requests Slade's commanding officer so that he can report the offense.
 
 #### Heroic Test of Deception (CR 20)
 
-Adele scans her multi-pass to gain entry to a level 5 sector of her office building, even though she only has clearance up to level 4. When the security sentry on duty questions her, Adele spins a tale about how she’s been having trouble with her multi-pass all day ever since she got caught in a mag storm on the way to work and that she’s just trying to get back into her office to grab her lunch.
+Adele scans her multi-pass to gain entry to a level 5 sector of her office building, even though she only has clearance up to level 4. When the security sentry on duty questions her, Adele spins a tale about how she's been having trouble with her multi-pass all day ever since she got caught in a mag storm on the way to work and that she's just trying to get back into her office to grab her lunch.
 
-**Success with a twist:** The sentry believes the story, but just to cover his butt he has to escort her to the office so that he doesn’t get in trouble.
+**Success with a twist:** The sentry believes the story, but just to cover his butt he has to escort her to the office so that he doesn't get in trouble.
 
 **Failure, but the story progresses:** The sentry is suspicious and tells Adele that he will need to contact his commanding officer about this.
 
 #### Epic Test of Deception (CR 25)
 
-The chronomancer Rapture has Sarge and his crew tied up as he prepares to unleash his dreaded Time Cannon upon the unsuspecting moon colony below. To power this attack, Rapture loads the Void Crystal, which he has recently stolen back from the heroes. In a final attempt to buy some time, Sarge lies through the skin of his teeth: “Too bad for you, Rapture, ‘cause we switched out the crystal back on Alpha Prime. I can’t wait to see what happens to your precious Time Cannon when you try to fire it with that ringer locked and loaded. With any luck, it will blow this whole ship to space dust.”
+The chronomancer Rapture has Sarge and his crew tied up as he prepares to unleash his dreaded Time Cannon upon the unsuspecting moon colony below. To power this attack, Rapture loads the Void Crystal, which he has recently stolen back from the heroes. In a final attempt to buy some time, Sarge lies through the skin of his teeth: “Too bad for you, Rapture, ‘cause we switched out the crystal back on Alpha Prime. I can't wait to see what happens to your precious Time Cannon when you try to fire it with that ringer locked and loaded. With any luck, it will blow this whole ship to space dust.”
 
-**Success with a twist:** Rapture is convinced enough to power down the cannon before it can finish charging, thus buying the heroes a little more time. In a fit of rage, though, he orders one of his lieutenant’s to slit Sarge’s throat, immediately applying the *death* bane.
+**Success with a twist:** Rapture is convinced enough to power down the cannon before it can finish charging, thus buying the heroes a little more time. In a fit of rage, though, he orders one of his lieutenant's to slit Sarge's throat, immediately applying the *death* bane.
 
-**Failure, but the story progresses:** Rapture calls Sarge’s bluff and immediately gives the command to fire.
+**Failure, but the story progresses:** Rapture calls Sarge's bluff and immediately gives the command to fire.
 
 ### Persuasion
 
@@ -475,25 +475,25 @@ Persuasion is the social attribute of negotiation and smooth talking. You make a
 
 #### Challenging Test of Persuasion (CR 15)
 
-Pelias is trying to trade a valuable ruby to the barkeep in exchange for the names of three gentlemen who were drinking at the tavern last night. The barkeep says he’ll give the rogue one name, so Pelias tries to convince him of the value of this gem in order to get all the info he needs.
+Pelias is trying to trade a valuable ruby to the barkeep in exchange for the names of three gentlemen who were drinking at the tavern last night. The barkeep says he'll give the rogue one name, so Pelias tries to convince him of the value of this gem in order to get all the info he needs.
 
-**Success with a twist:** The barkeep offers to give him two names. If he wants all three, he’ll have to throw in a sack of gold.
+**Success with a twist:** The barkeep offers to give him two names. If he wants all three, he'll have to throw in a sack of gold.
 
-**Failure, but the story progresses:** It’s clear that the barkeep is worried about more than just money. Pelias’ entreaties have spooked him completely and he won’t even give up a single name anymore.
+**Failure, but the story progresses:** It's clear that the barkeep is worried about more than just money. Pelias' entreaties have spooked him completely and he won't even give up a single name anymore.
 
 #### Heroic Test of Persuasion (CR 20)
 
-When they reach the town of Haven, the survivors find the gates closed. The guards inform them that the Overseer has placed a blockade on all outsiders due to reports of an outbreak of a new strain of Virus Z. With a few smooth words, Wendell manages to get the Overseer to come to the gate, but now he is attempting the much more difficult task of convincing him that his group isn’t infected and that they would be a valuable asset to the town.
+When they reach the town of Haven, the survivors find the gates closed. The guards inform them that the Overseer has placed a blockade on all outsiders due to reports of an outbreak of a new strain of Virus Z. With a few smooth words, Wendell manages to get the Overseer to come to the gate, but now he is attempting the much more difficult task of convincing him that his group isn't infected and that they would be a valuable asset to the town.
 
-**Success with a twist:** The Overseer finds the group’s deeds impressive and believes their story. However, he will accept them into Haven only if they agree to a one week quarantine, which will significantly delay their agenda.
+**Success with a twist:** The Overseer finds the group's deeds impressive and believes their story. However, he will accept them into Haven only if they agree to a one week quarantine, which will significantly delay their agenda.
 
-**Failure, but the story progresses:** The Overseer doesn’t care how valuable the group might be to his town, he simply cannot put his people at risk of another outbreak. He orders them away, and commands his guards to shoot them on sight if they return.
+**Failure, but the story progresses:** The Overseer doesn't care how valuable the group might be to his town, he simply cannot put his people at risk of another outbreak. He orders them away, and commands his guards to shoot them on sight if they return.
 
 #### Epic Test of Persuasion (CR 25)
 
 Professor Durst and his team of investigators have managed to take one of the Cultists of the Black Claw alive. The cultists are known to be diehard loyalists who will take the secrets of their guild to the grave, but Durst is well versed in the arts of psychological interrogation. He uses every mental tool at his disposal to get the cultist to see the error of his ways and aid their cause.
 
-**Success with a twist:** Durst has managed to leverage the cultist’s deeply suppressed emotion of guilt to get him to denounce the Black Claw. However, the terror of the dark deeds he has taken part in cannot be reconciled with the cultist’s former self, driving him insane. The cultist might provide some useful information to the investigators, but it is always hidden between maniacal ramblings and diabolical riddles.
+**Success with a twist:** Durst has managed to leverage the cultist's deeply suppressed emotion of guilt to get him to denounce the Black Claw. However, the terror of the dark deeds he has taken part in cannot be reconciled with the cultist's former self, driving him insane. The cultist might provide some useful information to the investigators, but it is always hidden between maniacal ramblings and diabolical riddles.
 
 **Failure, but the story progresses:** Durst thinks he has broken the cultist, and unties him as a show of goodwill. However, as soon as the cultist has the chance, he jumps through a nearby window and breaks his own neck in the fall.
 
@@ -503,7 +503,7 @@ Presence is the social attribute of leadership and charisma. A character with a 
 
 #### Challenging Test of Presence (CR 15)
 
-Shazben Hazben, the halfling bard, enters the tavern with a well-tuned mandolin but not even two coppers to scrape together. After striking up a conversation with the barkeep, Shazben offers to entertain the guests in exchange for room and board. The bartender likes the halfling’s style, so he gives him a chance to win him over on stage that night.
+Shazben Hazben, the halfling bard, enters the tavern with a well-tuned mandolin but not even two coppers to scrape together. After striking up a conversation with the barkeep, Shazben offers to entertain the guests in exchange for room and board. The bartender likes the halfling's style, so he gives him a chance to win him over on stage that night.
 
 **Success with a twist:** The crowd loves the halfling, even bringing in a few silver for tips. The barkeep says the bard can stay as long as he gets a cut of half the tips.
 
@@ -511,11 +511,11 @@ Shazben Hazben, the halfling bard, enters the tavern with a well-tuned mandolin 
 
 #### Heroic Test of Presence (CR 20)
 
-Gunner Dag has gotten himself into another one of his situations. He lost big at poker with a few of the local miners, used a bit of harsh language about one of their mother’s, and now he finds himself standing on main street at high noon, his Volt Pistol hanging at his hip and his eyes glaring at another stranger that he really doesn’t want to kill. He grits his teeth, hardens his eyes, and calls on every nerve of steel he has to overawe this yokel into backing down before things get bloody.
+Gunner Dag has gotten himself into another one of his situations. He lost big at poker with a few of the local miners, used a bit of harsh language about one of their mother's, and now he finds himself standing on main street at high noon, his Volt Pistol hanging at his hip and his eyes glaring at another stranger that he really doesn't want to kill. He grits his teeth, hardens his eyes, and calls on every nerve of steel he has to overawe this yokel into backing down before things get bloody.
 
-**Success with a twist:** The miner can see in Dag’s eyes that he is a born killer. He throws down his gun, but he still wants revenge. He will catch Dag in an alley later with many more thugs if he can.
+**Success with a twist:** The miner can see in Dag's eyes that he is a born killer. He throws down his gun, but he still wants revenge. He will catch Dag in an alley later with many more thugs if he can.
 
-**Failure, but the story progresses:** Dag’s hard eyes spook the miner into drawing his gun. Now the gunner has to decide if he’s going to kill the local or try to find another way out of this.
+**Failure, but the story progresses:** Dag's hard eyes spook the miner into drawing his gun. Now the gunner has to decide if he's going to kill the local or try to find another way out of this.
 
 #### Epic Test of Presence (CR 25)
 
@@ -523,7 +523,7 @@ The peasant militia is poorly trained, under armed, and small in number. Their o
 
 **Success with a twist:** Unfortunately for Maximus, the cowardly mayor is working against him. He has already convinced half of the militia to retreat with him and leave the village for the orcs to sack. The remaining half, however, are ready to die for their home alongside the paladin if need be.
 
-**Failure, but the story progresses:** Maximus doesn’t have what it takes to sway the hearts in so hopeless a cause. The militia disbands, and the village is surely lost to the orcs.
+**Failure, but the story progresses:** Maximus doesn't have what it takes to sway the hearts in so hopeless a cause. The militia disbands, and the village is surely lost to the orcs.
 
 ### Alteration
 
@@ -531,9 +531,9 @@ Alteration is the attribute of changing matter from one form to another. It can 
 
 #### Challenging Test of Alteration (CR 15)
 
-Svyll needs to reach the top of a short cliff, but he hasn’t the skill in climbing to manage. He is one with the earth, though, so he attempts to mold the cliff face temporarily to create a sort of stone ladder upon which he can ascend.
+Svyll needs to reach the top of a short cliff, but he hasn't the skill in climbing to manage. He is one with the earth, though, so he attempts to mold the cliff face temporarily to create a sort of stone ladder upon which he can ascend.
 
-**Success with a twist:** Svyll’s magic doesn’t fail him, but it doesn’t work as efficiently as expected and his climb takes twice as long as it should have.
+**Success with a twist:** Svyll's magic doesn't fail him, but it doesn't work as efficiently as expected and his climb takes twice as long as it should have.
 
 **Failure, but the story progresses:** Svyll fails to take into account the delicate nature of the cliff, causing a small landslide to fall upon his party. However, when they pick themselves out of the rubble, they discover that the landslide revealed a cavern opening that was previously concealed.
 
@@ -541,17 +541,17 @@ Svyll needs to reach the top of a short cliff, but he hasn’t the skill in clim
 
 Wrench and his squad are being pursued through the corridors of a wrecked space station by a horde of cannibalistic mutants. While the mutants are temporarily delayed breaking down one of the blast doors, Wrench attempts to animate the electronic gizmos in the room to slow down the horde and buy the group enough time to get back to their ship.
 
-**Success with a twist**: It looks like it’s going to take Wrench a little longer to spring his trap than he thought. The GM says that the rest of his party will have to fend off the mutants for five rounds to buy Wrench enough time, forcing them to make a tough decision.
+**Success with a twist**: It looks like it's going to take Wrench a little longer to spring his trap than he thought. The GM says that the rest of his party will have to fend off the mutants for five rounds to buy Wrench enough time, forcing them to make a tough decision.
 
-**Failure, but the story progresses:** The spare parts in the room just aren’t good enough to work with. However, Wrench does discover a ventilation shaft in the ceiling that could provide an alternate means of escape… if the mutants don’t already know about it.
+**Failure, but the story progresses:** The spare parts in the room just aren't good enough to work with. However, Wrench does discover a ventilation shaft in the ceiling that could provide an alternate means of escape… if the mutants don't already know about it.
 
 #### Epic Test of Alteration (CR 25)
 
-Artemis isn’t going to let a little thing like a thrice-locked stone door keep him from the king’s vault. With arcane words and gestures, he attempts to dig a hole right through the door.
+Artemis isn't going to let a little thing like a thrice-locked stone door keep him from the king's vault. With arcane words and gestures, he attempts to dig a hole right through the door.
 
-**Success with a twist:** Artemis doesn’t have the power to burrow through the wall. It seems that some arcane magic protects the stone. However, he is able to use his magic to disable one of the three locks.
+**Success with a twist:** Artemis doesn't have the power to burrow through the wall. It seems that some arcane magic protects the stone. However, he is able to use his magic to disable one of the three locks.
 
-**Failure, but the story progresses:** Before Artemis’s magic can work its wonders on the stone, a magical trap springs and zaps the wizard, draining some of his hit points and leaving him unable to get past the door.
+**Failure, but the story progresses:** Before Artemis's magic can work its wonders on the stone, a magical trap springs and zaps the wizard, draining some of his hit points and leaving him unable to get past the door.
 
 ### Creation
 
@@ -561,9 +561,9 @@ Creation is the attribute of healing and forming matter out of nothing. It can b
 
 Jaaxy is trying to gain entrance into headquarters of the Order of Outlanders, but she lacks an appropriate keystone attuned to her biometrics required by the door guards. Having studied the shattered remains of a keystone acquired from a previous member of the Order, Jaaxy sits in her lab attempting to create a new one.
 
-**Success with a twist:** Jaaxy’s keystone is good enough to get her through the door. However, it loses its biometric attunement shortly after she enters the headquarters.
+**Success with a twist:** Jaaxy's keystone is good enough to get her through the door. However, it loses its biometric attunement shortly after she enters the headquarters.
 
-**Failure, but the story progresses:** Jaaxy thinks her creation is perfect, but the door guards aren’t fooled so easily. They call her on the forgery and imprison her. She’s within the headquarters, just not on her own terms.
+**Failure, but the story progresses:** Jaaxy thinks her creation is perfect, but the door guards aren't fooled so easily. They call her on the forgery and imprison her. She's within the headquarters, just not on her own terms.
 
 #### Heroic Test of Creation (CR 20)
 
@@ -571,36 +571,36 @@ Therilas is attempting to lead a party of refugees safely through the Decaying D
 
 **Success with a twist:** The only way that Therilas is able to harness enough energy to feed so many people is to draw on his own life reserves. The GM rules that he suffers one level of the *fatigued* bane.
 
-**Failure, but the story progresses:** Unfortunately, despite his best efforts, Therilas can only create half of the food and water that it would take to adequately sustain the refugees. Half of them won’t survive the journey without further intervention.
+**Failure, but the story progresses:** Unfortunately, despite his best efforts, Therilas can only create half of the food and water that it would take to adequately sustain the refugees. Half of them won't survive the journey without further intervention.
 
 #### Epic Test of Creation (CR 25)
 
 Father Ezekiel is stranded on a jungle island. He attempts to use divine magic to create a ship out of nothing so that he may escape his plight.
 
-**Success with a twist:** The GM rules that Father’s magic will only be strong enough to create the ship if he can find a magical focus of appropriate power somewhere within the island.
+**Success with a twist:** The GM rules that Father's magic will only be strong enough to create the ship if he can find a magical focus of appropriate power somewhere within the island.
 
 **Failure, but the story progresses:** Father thinks he has crafted a seaworthy vessel. However, shortly after setting sail, the magic binding his ship together unweaves, and he is forced to swim against the tides or die trying.
 
 ### Energy
 
 Energy is the extraordinary attribute that governs control and creation of elemental energy. Though the list is not exhaustive, typical energy types include fire, ice, electricity, water, earth, acid, plasma, and lasers. You could be called upon to make an energy roll when you attempt to create flame out of nothing, calm rough waters at sea, or power up a futuristic plasma cannon beyond the normal range of technology for your setting.
-A character’s energy score governs their skill at manipulating all forms of energy, though the character must have a logical explanation for individual uses of this attribute. For example, a storm mage could use energy for manipulating electricity, thunder, water, and wind - but the GM might not allow him to summon ice and fire.
+A character's energy score governs their skill at manipulating all forms of energy, though the character must have a logical explanation for individual uses of this attribute. For example, a storm mage could use energy for manipulating electricity, thunder, water, and wind - but the GM might not allow him to summon ice and fire.
 
 #### Challenging Test of Energy (CR 15)
 
 Asger and Hertha have trekked long and hard through the frozen Fjords of the Titans, and as night falls they manage to take shelter in a cave before the midnight winds drop the temperature to deadly levels. Still, the cave is cold, and though Asger starts a meager fire to keep them warm, Hertha attempts to use her fire magic to maintain and multiply the heat so that they can both rest peacefully.
 
-**Success with a twist:** Hertha’s spell works, though the cold is stronger than she realized. In order to maintain the magic throughout the night, she must sacrifice a component of minor value to empower her charm. With the GM’s approval, Hertha decides to melt down her golden bracelet to power the spell.
+**Success with a twist:** Hertha's spell works, though the cold is stronger than she realized. In order to maintain the magic throughout the night, she must sacrifice a component of minor value to empower her charm. With the GM's approval, Hertha decides to melt down her golden bracelet to power the spell.
 
-**Failure, but the story progresses:** Asger’s fire is enough to keep them from freezing to death, but without Hertha’s magic, they are still quite frostbitten and exhausted by the morning. Both PCs suffer one level of the *fatigue* bane.
+**Failure, but the story progresses:** Asger's fire is enough to keep them from freezing to death, but without Hertha's magic, they are still quite frostbitten and exhausted by the morning. Both PCs suffer one level of the *fatigue* bane.
 
 #### Heroic Test of Energy (CR 20)
 
-Doctor Heller has accompanied his posse on the raid of a train transporting a large sum of Pinkerton cash. They’ve neutralized the guards and taken control of the train, but they still have to get the safe open. Doc powers up his patented Slow Drip Acidic Disseminator and attempts to burn through the lock with expert precision.
+Doctor Heller has accompanied his posse on the raid of a train transporting a large sum of Pinkerton cash. They've neutralized the guards and taken control of the train, but they still have to get the safe open. Doc powers up his patented Slow Drip Acidic Disseminator and attempts to burn through the lock with expert precision.
 
-**Success with a twist:** Doc’s mad science works a bit too well as the Disseminator overloads and burns through the entire door of the safe, destroying about one-fifth of the score along with it.
+**Success with a twist:** Doc's mad science works a bit too well as the Disseminator overloads and burns through the entire door of the safe, destroying about one-fifth of the score along with it.
 
-**Failure, but the story progresses:** It turns out the safe has been coated with a corrosion proof chemical that renders Doc’s acid harmless. The good news is that Doc is smart enough to recognize this. The bad news is that it takes him so long to figure it out that the Pinkerton reinforcements have arrived on horseback.
+**Failure, but the story progresses:** It turns out the safe has been coated with a corrosion proof chemical that renders Doc's acid harmless. The good news is that Doc is smart enough to recognize this. The bad news is that it takes him so long to figure it out that the Pinkerton reinforcements have arrived on horseback.
 
 #### Epic Test of Energy (CR 25)
 
@@ -618,9 +618,9 @@ Entropy is the extraordinary attribute of destruction, death, and negative energ
 
 Gizmo is attempting to bypass a lock on a mundane door using his Pocket Matter Disintegration Device. He focuses the beam on the lock and rolls to remove it from existence.
 
-**Success with a twist:** Gizmo’s device works, but overheats in the process due to the volatile nature of his mad science. He can’t use it again until he has the time and equipment to make repairs.
+**Success with a twist:** Gizmo's device works, but overheats in the process due to the volatile nature of his mad science. He can't use it again until he has the time and equipment to make repairs.
 
-**Failure, but the story progresses:** The device overheats before it can get fully powered up and explodes in Gizmo’s face. He suffers the *blinded* bane, and the loud noise alerts the guards down the hallway.
+**Failure, but the story progresses:** The device overheats before it can get fully powered up and explodes in Gizmo's face. He suffers the *blinded* bane, and the loud noise alerts the guards down the hallway.
 
 #### Heroic Test of Entropy (CR 20)
 
@@ -628,7 +628,7 @@ Balthazar has delved deep into the Tomb of Aliki to gain access to the powerful 
 
 **Success with a twist:** The spell works, though the ghost is unimpressed. Aliki animates the shadows to attack the necromancer, stating that Balthazar can prove his worthiness by defeating the shadows.
 
-**Failure, but the story progresses:** Balthazar’s spell fails, and the shadows do not bend to his will. With a maniacal laugh, Aliki attacks the necromancer, attempting to inflict the *death* bane.
+**Failure, but the story progresses:** Balthazar's spell fails, and the shadows do not bend to his will. With a maniacal laugh, Aliki attacks the necromancer, attempting to inflict the *death* bane.
 
 #### Epic Test of Entropy (CR 25)
 
@@ -636,7 +636,7 @@ Coach and his team of survivors have located another one of the Apocalypse Gates
 
 **Success with a twist:** Liza must contend with a hell knight who stands on the other side of the portal, using all of his will to thwart her magic. She comes out stronger and closes the portal, though the mental battle scars her for life. She suffers a permanent level of the *fatigue* bane until she can find a means to cure herself.
 
-**Failure, but the story progresses:** Although she doesn’t have the power to close the Apocalypse Gate, Liza realizes that it is being maintained by a hell knight on the other side. If her team dares to enter the portal and slay him, the gate should close.
+**Failure, but the story progresses:** Although she doesn't have the power to close the Apocalypse Gate, Liza realizes that it is being maintained by a hell knight on the other side. If her team dares to enter the portal and slay him, the gate should close.
 
 ### Influence
 
@@ -654,45 +654,45 @@ Ensign Destiny attempts to convince the bouncer at the cantina that her friends 
 
 Shipwrecked on a remote jungle island, Allister and his companions find themselves surrounded by a horde of tiny tribal lizard men out for blood. With a grand show of illusory lights, Allister attempts to use his magic to convince the lizards that he was sent from the stars to command them.
 
-**Success with a twist:** The lizards are convinced of Allister’s god-like nature, but they still do not trust his companions, treating them as mere slaves of a god.
+**Success with a twist:** The lizards are convinced of Allister's god-like nature, but they still do not trust his companions, treating them as mere slaves of a god.
 
-**Failure, but the story progresses:** A shaman among the lizardfolk recognizes Allister’s illusions and calls him out on them. The lizards, inflamed with rage at the deception, launch an attack.
+**Failure, but the story progresses:** A shaman among the lizardfolk recognizes Allister's illusions and calls him out on them. The lizards, inflamed with rage at the deception, launch an attack.
 
 #### Epic Test of Influence (CR 25)
 
-The only thing that stands between Sir Thomas and the Sword of Light is an undead skeletal dragon named Char. Char engages the paladin in a test of words, attempting to use his wyrm speak to ensorcel Thomas. Never one for words, Sir Thomas relies instead on his divine magic, channeling the power of his goddess to strike fear in Char’s undead heart and make him quit his word games.
+The only thing that stands between Sir Thomas and the Sword of Light is an undead skeletal dragon named Char. Char engages the paladin in a test of words, attempting to use his wyrm speak to ensorcel Thomas. Never one for words, Sir Thomas relies instead on his divine magic, channeling the power of his goddess to strike fear in Char's undead heart and make him quit his word games.
 
-**Success with a twist:** Sir Thomas’s prayer is heard, though Char’s power is greater than the paladin realized. The dragon fails to completely ensorcel Thomas, but when the fight breaks out, the paladin begins with the *stunned* bane.
+**Success with a twist:** Sir Thomas's prayer is heard, though Char's power is greater than the paladin realized. The dragon fails to completely ensorcel Thomas, but when the fight breaks out, the paladin begins with the *stunned* bane.
 
-**Failure, but the story progresses:** Sir Thomas is far from his god in this dank pit and cannot channel enough divine power to overcome the dragon’s wyrm tongue. Before he realizes what he has done, the paladin has revealed his deepest secrets to the ancient beast. Thomas begins the fight with the *stunned* bane and Char gains advantage 1 on every action roll throughout the combat due to his deep knowledge of the paladin’s inner self.
+**Failure, but the story progresses:** Sir Thomas is far from his god in this dank pit and cannot channel enough divine power to overcome the dragon's wyrm tongue. Before he realizes what he has done, the paladin has revealed his deepest secrets to the ancient beast. Thomas begins the fight with the *stunned* bane and Char gains advantage 1 on every action roll throughout the combat due to his deep knowledge of the paladin's inner self.
 
 ### Movement
 
-Movement governs extraordinary means of locomotion, travel, and speed - as well as secondary effects that are tied to these spheres. Movement is typically used to invoke boons such as *haste*, *teleport*, and *flight*. However, the GM may call for a straight Movement roll when the success of the action isn’t tied so much to the successful invocation of the boon as it is to the circumstances of the action. The examples below illustrate such instances.
+Movement governs extraordinary means of locomotion, travel, and speed - as well as secondary effects that are tied to these spheres. Movement is typically used to invoke boons such as *haste*, *teleport*, and *flight*. However, the GM may call for a straight Movement roll when the success of the action isn't tied so much to the successful invocation of the boon as it is to the circumstances of the action. The examples below illustrate such instances.
 
 #### Challenging Test of Movement (CR 15)
 
-Victoria is trying to create enough of a distraction to allow her ally, Nick, to escape from the two junkyard thugs who have him at gun point. She taps into her telekinetic powers to create a storm of debris from the junk littered around the area, attempting to throw the thugs’ attention away from Nick.
+Victoria is trying to create enough of a distraction to allow her ally, Nick, to escape from the two junkyard thugs who have him at gun point. She taps into her telekinetic powers to create a storm of debris from the junk littered around the area, attempting to throw the thugs' attention away from Nick.
 
 **Success with a twist:** The whirlwind of junk distracts the guards long enough to let Nick dive behind some cover and grab an improvised weapon, but the thugs are right on his tail.
 
-**Failure, but the story progresses:** Nick thinks he’s got a chance to make a break for it, but Victoria’s powers fail her at just the wrong moment, and one of the thugs pistol whips Nick unconscious as he attempts to escape.
+**Failure, but the story progresses:** Nick thinks he's got a chance to make a break for it, but Victoria's powers fail her at just the wrong moment, and one of the thugs pistol whips Nick unconscious as he attempts to escape.
 
 #### Heroic Test of Movement (CR 20)
 
-Gizmo’s party is attempting to evade a pack of wererats amidst the narrow alleys and busy streets of Ystril. The GM asks each PC to describe what they are doing to escape their pursuers. Gizmo decides to rely on the power of his patented Mark VI Rocket Boots to propel him from rooftop to rooftop.
+Gizmo's party is attempting to evade a pack of wererats amidst the narrow alleys and busy streets of Ystril. The GM asks each PC to describe what they are doing to escape their pursuers. Gizmo decides to rely on the power of his patented Mark VI Rocket Boots to propel him from rooftop to rooftop.
 
-**Success with a twist:** Much to the surprise of his allies, Gizmo’s invention does the trick, and he easily evades the wererats pursuing him. However, he has pushed them to the limit, and they will not function again until he can get access to a workshop and repair them.
+**Success with a twist:** Much to the surprise of his allies, Gizmo's invention does the trick, and he easily evades the wererats pursuing him. However, he has pushed them to the limit, and they will not function again until he can get access to a workshop and repair them.
 
-**Failure, but the story progresses:** Gizmo’s Rocket Boots hurl him haphazardly about the city, and to no one’s surprise, they conk out mid-air in an explosion of gears and smoke, sending the gnome hurdling into dark alley. When he gets to his feet, he finds himself flanked by wererats.
+**Failure, but the story progresses:** Gizmo's Rocket Boots hurl him haphazardly about the city, and to no one's surprise, they conk out mid-air in an explosion of gears and smoke, sending the gnome hurdling into dark alley. When he gets to his feet, he finds himself flanked by wererats.
 
 #### Epic Test of Movement (CR 25)
 
-Wings is piloting the escape pod his crew used to break free from InterGal HQ. Their escape did not go unnoticed, however, and the pod is being pulled back in by the star cruiser’s tractor beam. In a last ditch effort to secure their freedom, Wings jacks himself into the pod’s power matrix and attempts to use every trick up his sleeve to boost its velocity beyond the force of the tractor beam.
+Wings is piloting the escape pod his crew used to break free from InterGal HQ. Their escape did not go unnoticed, however, and the pod is being pulled back in by the star cruiser's tractor beam. In a last ditch effort to secure their freedom, Wings jacks himself into the pod's power matrix and attempts to use every trick up his sleeve to boost its velocity beyond the force of the tractor beam.
 
-**Success with a twist:** Wings manages to override all of the pod’s failsafes in order to redirect every ounce of it’s power into the forward thrust. The ship escapes the tractor beam, but it’s navigation systems get fried in the process. The crew no longer has control over their trajectory.
+**Success with a twist:** Wings manages to override all of the pod's failsafes in order to redirect every ounce of it's power into the forward thrust. The ship escapes the tractor beam, but it's navigation systems get fried in the process. The crew no longer has control over their trajectory.
 
-**Failure, but the story progresses:** Wings can’t break the ship’s safety protocols, and the pod is quickly swallowed back into InterGal HQ. It will only be a matter of minutes until they are swarmed by Galactic Troops.
+**Failure, but the story progresses:** Wings can't break the ship's safety protocols, and the pod is quickly swallowed back into InterGal HQ. It will only be a matter of minutes until they are swarmed by Galactic Troops.
 
 
 ### Prescience
@@ -705,7 +705,7 @@ The crew is barricaded in the sporting goods store of the mall with a horde of z
 
 **Success with a twist:** Victoria gets impressions of death in the air ducts, but she is a neophyte in the ways of her powers, and suffers a severe headache before she can get a reading on the loading bay.
 
-**Failure, but the story progresses:** Victoria’s mind is too cluttered by the moans and groans of the undead to effectively get a reading. Even worse, the zombies have started to tear down the gate, so the group must make a decision immediately on which path to take.
+**Failure, but the story progresses:** Victoria's mind is too cluttered by the moans and groans of the undead to effectively get a reading. Even worse, the zombies have started to tear down the gate, so the group must make a decision immediately on which path to take.
 
 #### Heroic Test of Prescience (CR 20)
 
@@ -717,7 +717,7 @@ As Shane chased him through the corridors of Payne Manor, the Doctor ducked into
 
 #### Epic Test of Prescience (CR 25)
 
-Ruby is investigating the scene of the lord mayor’s assassination. There are no obvious physical signs of the cause of death, so she touches her hand to the mayor’s heart and attempts to communicate with his spirit and learn whatever she can. 
+Ruby is investigating the scene of the lord mayor's assassination. There are no obvious physical signs of the cause of death, so she touches her hand to the mayor's heart and attempts to communicate with his spirit and learn whatever she can. 
 
 **Success with a twist:** Ruby can speak briefly with the mayor. However, her connection with his troubled soul becomes semi-permanent. She is tortured by his desire for vengeance until his killer is brought to justice. While this effect persists, Ruby suffers one level of the *fatigued* bane.
 
@@ -725,7 +725,7 @@ Ruby is investigating the scene of the lord mayor’s assassination. There are n
 
 ### Protection
 
-The Protection attribute represents a character’s extraordinary means of preventing harm, warding off danger, and breaking unwanted control. You might make a Protection roll in order to keep allies safe in the face of a trap or hazard, prevent unwanted creatures from approaching, or hold back a powerful force of nature.
+The Protection attribute represents a character's extraordinary means of preventing harm, warding off danger, and breaking unwanted control. You might make a Protection roll in order to keep allies safe in the face of a trap or hazard, prevent unwanted creatures from approaching, or hold back a powerful force of nature.
 
 #### Challenging Test of Protection (CR 15)
 
@@ -733,15 +733,15 @@ As Balthazar and his companions make their way up the narrow ledge that encircle
 
 **Success with a twist:** Balthazar manages to complete his spell, but his shield is not as big as he had hoped, and two of his companions must still resist the winds on their own.
 
-**Failure, but the story progresses:** The mighty gale hurls Balthazar’s staff from his hands before he can finish the spell. Now he must not only fight to remain on the cliff, but he also risks losing his staff.
+**Failure, but the story progresses:** The mighty gale hurls Balthazar's staff from his hands before he can finish the spell. Now he must not only fight to remain on the cliff, but he also risks losing his staff.
 
 #### Heroic Test of Protection (CR 20)
 
-Star and her platoon pilot their mechanized combat suits through the wastelands of Primus, the first moon of New Terra. During the their week-long trek, one of Primus’ much-feared corrosive acid clouds settles over the soldiers, threatening to slowly eat away at their armor. The GM asks each PC what they are doing to protect their mechs, and Star decides to use her Protection attribute to activate her suit’s enviro shields to ward off the acid.
+Star and her platoon pilot their mechanized combat suits through the wastelands of Primus, the first moon of New Terra. During the their week-long trek, one of Primus' much-feared corrosive acid clouds settles over the soldiers, threatening to slowly eat away at their armor. The GM asks each PC what they are doing to protect their mechs, and Star decides to use her Protection attribute to activate her suit's enviro shields to ward off the acid.
 
-**Success with a twist:** Star’s enviro shield does the trick, but the acid storm is so strong that she is forced to reroute power from her mech’s combat defenses in order to maintain the shield. As long as she keeps her enviro shield up, Star’s max HP is reduced by 5. 
+**Success with a twist:** Star's enviro shield does the trick, but the acid storm is so strong that she is forced to reroute power from her mech's combat defenses in order to maintain the shield. As long as she keeps her enviro shield up, Star's max HP is reduced by 5. 
 
-**Failure, but the story progresses:** Star’s enviro shield just wasn’t meant for such prolonged exposure to corrosive matter of this level. After three days in the acid cloud, her mech’s hull is severely corroded, reducing her Armor bonus by 3 until it can be repaired.
+**Failure, but the story progresses:** Star's enviro shield just wasn't meant for such prolonged exposure to corrosive matter of this level. After three days in the acid cloud, her mech's hull is severely corroded, reducing her Armor bonus by 3 until it can be repaired.
 
 #### Epic Test of Protection (CR 25)
 
@@ -749,4 +749,4 @@ Despite the warning of her mentor sage, Bell has dared to glimpse into the accur
 
 **Success with a twist:** Bell manages to regain control of herself and close the book. However, unbeknownst to her, one of the demons remains and will assail her from time to time until she discovers and has it properly exorcised.
 
-**Failure, but the story progresses:** Bell’s magic is not strong enough to hold back the forces of hell, and she is compelled to read from the book for hours on end. When the attack finally ends, Bell is changed. She has permanently gained the *psychotic* flaw.
+**Failure, but the story progresses:** Bell's magic is not strong enough to hold back the forces of hell, and she is compelled to read from the book for hours on end. When the attack finally ends, Bell is changed. She has permanently gained the *psychotic* flaw.

--- a/core/src/03-feats/01-chapter-three.md
+++ b/core/src/03-feats/01-chapter-three.md
@@ -1,6 +1,6 @@
 # Chapter 3: Feats #
 
-In this chapter, you’ll find complete descriptions of all of the feats available to customize your character in Open Legend. Feats are used to define your character’s specializations, the actions, tasks, and abilities they excel at beyond all others. Some feats will enhance your major actions, such as by allowing you to multi-attack with reduced disadvantage, while others will grant you completely new powers, such as the ability to change your shape.
+In this chapter, you'll find complete descriptions of all of the feats available to customize your character in Open Legend. Feats are used to define your character's specializations, the actions, tasks, and abilities they excel at beyond all others. Some feats will enhance your major actions, such as by allowing you to multi-attack with reduced disadvantage, while others will grant you completely new powers, such as the ability to change your shape.
 
 ## Acquiring Feats
 

--- a/core/src/04-wealth-equipment/01-chapter-four.md
+++ b/core/src/04-wealth-equipment/01-chapter-four.md
@@ -1,7 +1,7 @@
 
 # Chapter 4: Wealth & Equipment #
 
-No story of heroic deeds is complete without equally heroic gear, weapons and armor. Indiana Jones had his whip, King Arthur had *Excalibur*, and Bilbo had his mithril shirt. In this chapter, you’ll learn everything you need to know about how to equip your character at first level and beyond, as well as how to keep track of your wealth as you claim space pirate bounties and dip your hands in the coffers of kings.
+No story of heroic deeds is complete without equally heroic gear, weapons and armor. Indiana Jones had his whip, King Arthur had *Excalibur*, and Bilbo had his mithril shirt. In this chapter, you'll learn everything you need to know about how to equip your character at first level and beyond, as well as how to keep track of your wealth as you claim space pirate bounties and dip your hands in the coffers of kings.
 
 ## Wealth
 Rather than tracking every gold piece, credit, or fine art object that you acquire over the course of your adventures, Open Legend uses a simplified wealth system.
@@ -13,7 +13,7 @@ When you are trying to buy new equipment, construct a building, or hire a crafts
 
 If the good you want to purchase has a level lower than your Wealth Score, you can acquire the item easily without taxing your time and resources.
 
-If the item’s level is **equal to** your Wealth Score, you can acquire it, but the expense taxes your resources such that you cannot acquire new goods at that level or higher for two weeks.
+If the item's level is **equal to** your Wealth Score, you can acquire it, but the expense taxes your resources such that you cannot acquire new goods at that level or higher for two weeks.
 
 If the object of your purchase is **one level higher than** your Wealth Score and your Wealth Score is above 0, you can acquire it, but the cost is so great that your Wealth Score is reduced by 1.
 
@@ -49,13 +49,13 @@ You cannot make purchases that are more than one level higher than your Wealth S
 >
 > Crazy Mac has panhandled his way up to a wealth score of 1. From now on, he can afford 3 square meals and a warm bed every night, because they are priced at wealth level 0.
 
-**The Rule of Common Sense**. Your Wealth Score determines which purchases are possible given the proper circumstances. Obviously, if you are in the middle of a desert, you can’t buy a keg of water even if you have the wealth of an emperor. Likewise, even though you have enough money to raise an army, the GM may rule that you still require the appropriate amount of time, effort, and charisma to convince the soldiers to follow you.
+**The Rule of Common Sense**. Your Wealth Score determines which purchases are possible given the proper circumstances. Obviously, if you are in the middle of a desert, you can't buy a keg of water even if you have the wealth of an emperor. Likewise, even though you have enough money to raise an army, the GM may rule that you still require the appropriate amount of time, effort, and charisma to convince the soldiers to follow you.
 
 ### Gaining Wealth
 
-As you travel the stars, slay mythic beasts, and win over affluent nobles, your wealth will increase. The GM decides when a character’s wealth increases, and the Wealth Overview table provides a few milestones of typical character Wealth Scores at different levels.
+As you travel the stars, slay mythic beasts, and win over affluent nobles, your wealth will increase. The GM decides when a character's wealth increases, and the Wealth Overview table provides a few milestones of typical character Wealth Scores at different levels.
 
-Typical situations of when the GM would grant you an increase in your Wealth Score include acquiring a large hoard from a monster’s lair, finding a buyer for an item of great power or value, or being rewarded by a great ruler.
+Typical situations of when the GM would grant you an increase in your Wealth Score include acquiring a large hoard from a monster's lair, finding a buyer for an item of great power or value, or being rewarded by a great ruler.
 
 ## Carrying Capacity
 
@@ -63,17 +63,17 @@ Typical situations of when the GM would grant you an increase in your Wealth Sco
 
 ### Twenty Items Max
 
-You can carry up to twenty pieces of gear. No more. Only track the items that will actually affect the game. So, no, you don’t need to record your pants and shirt on your character sheet. But, your armor does count.
+You can carry up to twenty pieces of gear. No more. Only track the items that will actually affect the game. So, no, you don't need to record your pants and shirt on your character sheet. But, your armor does count.
 
 Multiple items of a similar nature that can be stowed together, such as twenty arrows in a quiver or a belt of healing potions, only count as a single item. The GM can use their own discretion to apply common sense limits if necessary. For example, even though technically 1000 clips of ammo would count as a single item, the GM is free to rule that a PC can't carry them or that they would count as a *bulky* item (see below).
 
 ### Maximum *Heavy* Items Equals Might Score
 
-Some items have the *heavy* property. You can carry a number of *heavy* items equal to your Might score. Once you’re carrying your maximum number of *heavy* items, your speed is cut in half. A character with a zero Might score cannot carry any heavy items.
+Some items have the *heavy* property. You can carry a number of *heavy* items equal to your Might score. Once you're carrying your maximum number of *heavy* items, your speed is cut in half. A character with a zero Might score cannot carry any heavy items.
 
 ### One (Maybe Two) *Bulky* Items
 
-Some items have the *bulky* property. You can carry one *bulky* item at no penalty. You can carry a second *bulky* item, but your speed is reduced to 5’.
+Some items have the *bulky* property. You can carry one *bulky* item at no penalty. You can carry a second *bulky* item, but your speed is reduced to 5'.
 
 
 > #### Tech Levels
@@ -105,22 +105,22 @@ In this section you will find the tools needed to pick weapons and armor that yo
 
 * **Melee** - weapons in this category are meant for close quarters hand-to-hand combat.
 
-    * **One-handed Melee** - The weapon uses a single hand and allows the other hand to be used for carrying another object, second weapon, or kept free for other actions. When wielding a one-handed weapon in each hand, you gain advantage 1 to all melee attacks; with two weapons, you have a better chance of capitalizing on openings in your target’s defense. If both weapons you are wielding have passive benefits such as the Deadly or Defensive properties, your benefit is the best of the two but does not stack.
+    * **One-handed Melee** - The weapon uses a single hand and allows the other hand to be used for carrying another object, second weapon, or kept free for other actions. When wielding a one-handed weapon in each hand, you gain advantage 1 to all melee attacks; with two weapons, you have a better chance of capitalizing on openings in your target's defense. If both weapons you are wielding have passive benefits such as the Deadly or Defensive properties, your benefit is the best of the two but does not stack.
     * **Two-Handed Melee** - The weapon requires two hands to wield and cannot be used with a shield or other weapon. Two-handed melee weapons grant advantage 1 to all attacks; blows delivered with both hands are usually more deadly.
     * **Versatile Melee** - The weapon can be wielded either one-handed or two-handed. The wielder can freely switch between the two modes and has all of the benefits and restrictions of whichever mode they are using.
 
 * **Ranged** - Weapons in this category can be used to make ranged attacks with no penalty up to their range increment (in feet). Attacks made up to twice the normal range suffer disadvantage 1, and attacks made up to three times the normal range suffer disadvantage 2. Attacks at farther distances cannot be made. Note that ammunition for ranged weapons is generally not kept track of, as it is assumed you have brought enough ammo with you. A weapon like a rocket launcher should be handled as one-time use, consumable extraordinary item.
     * **Range Increments**
 
-        * **Close Ranged** - Range increment of 25’.
-        * **Short Ranged** - Range increment of 50’.
-        * **Medium Ranged** - Range increment of 75’.
-        * **Long Ranged** - Range increment of 125’.
-        * **Extreme Ranged** - Range increment of 300’.
+        * **Close Ranged** - Range increment of 25'.
+        * **Short Ranged** - Range increment of 50'.
+        * **Medium Ranged** - Range increment of 75'.
+        * **Long Ranged** - Range increment of 125'.
+        * **Extreme Ranged** - Range increment of 300'.
 
     * **Close** and **Short** Ranged weapons are built to be compact and effective in close quarters, so they are less bulky. They can be wielded with a single hand, allowing the other hand to be used for carrying a shield, second weapon, or kept free for other actions.
     * **Medium**, **Long**, and **Extreme** Ranged weapons have various strengths, but are not built for close quarters combat. As such, they require two hands and cannot be used with any weapon or other item in the wielders off hand.
-    * **Extreme** Ranged weapons are built for distance and given their specialized calibration, cannot be used to attack a target closer than 50’.
+    * **Extreme** Ranged weapons are built for distance and given their specialized calibration, cannot be used to attack a target closer than 50'.
 
 **WL (Wealth Level)** is an indication of how expensive the item is to purchase. See the **Wealth** section earlier in this chapter for an explanation of how that works.
 
@@ -189,11 +189,11 @@ In this section you will find the tools needed to pick weapons and armor that yo
 
 **Precise** - This weapon can be used to make attacks with the Agility attribute  and invoke banes accessible via Agility.
 
-**Reach** - The weapon can be used to attack enemies 10’ away.
+**Reach** - The weapon can be used to attack enemies 10' away.
 
 **Slow** - If you are wielding this weapon at the beginning of combat, you gain disadvantage 2 on your initiative roll. If you are not wielding the weapon but plan to use it on your first turn, this penalty is applied. If you are wielding multiple weapons, your initiative modifier is equal to the slowest among them (slow, swift, or neither).
 
-**Stationary** - the bulk and weight of this weapon is enormous. Moving it requires a Focus Action from an assisting character which transports the weapon 30’.
+**Stationary** - the bulk and weight of this weapon is enormous. Moving it requires a Focus Action from an assisting character which transports the weapon 30'.
 
 **Swift** - If you are wielding this weapon at the beginning of combat, you gain advantage 2 on your initiative roll. If you are not wielding the weapon but plan to use it on your first turn, you get this bonus. If you are wielding multiple weapons, your initiative modifier is equal to the slowest among them (slow, swift, or neither).
 
@@ -216,7 +216,7 @@ The Armor table summarizes the following properties of each type of armor:
 
 **Speed Penalty** indicates the reduction in speed that your character suffers due to the bulkiness and weight of the armor.
 
-Donning and removing armor takes 1 round for light armor, 1 minute for medium armor, and 10 minutes for heavy armor. Sleeping in medium or heavy armor is only possible with special training. Without the Armor Mastery feat, sleeping in armor causes your character to gain one level of the Fatigued bane, which applies disadvantage 1 to all action rolls until they get a proper night’s rest.
+Donning and removing armor takes 1 round for light armor, 1 minute for medium armor, and 10 minutes for heavy armor. Sleeping in medium or heavy armor is only possible with special training. Without the Armor Mastery feat, sleeping in armor causes your character to gain one level of the Fatigued bane, which applies disadvantage 1 to all action rolls until they get a proper night's rest.
 
 <div class="table-no-body"></div>
 | Armor |
@@ -228,7 +228,7 @@ Donning and removing armor takes 1 round for light armor, 1 minute for medium ar
 | Leather Armor, Padding, Steelsilk | Light | 1 | 0 | 1 | 0 |
 | Kevlar Vest, Bioweave | Medium | 2 | 2 | 2 | 0 |
 | Chain Shirt, Full Body Armor | Medium | 2 | 3 | 2 | 0 |
-| Yoroi Armor, Plate Mail | Heavy | 2 | 3 | 3 | 5’ |
+| Yoroi Armor, Plate Mail | Heavy | 2 | 3 | 3 | 5' |
 | Power Armor, Elven Plate Mail | Heavy | 4 | 1 | 3 | 0 |
 
 \
@@ -237,11 +237,11 @@ Donning and removing armor takes 1 round for light armor, 1 minute for medium ar
 
 ## Building Your Own Weapons
 
-Open Legend is all about freeform creativity, so we’ve given you lots of examples with the Weapons table, but the list is by no means exhaustive. If you want to build your own custom weapon, follow the steps below
+Open Legend is all about freeform creativity, so we've given you lots of examples with the Weapons table, but the list is by no means exhaustive. If you want to build your own custom weapon, follow the steps below
 
 ### Step 1: Choose a Category
 
-Typically a weapon belongs to one category, however some weapons, such as a dagger or a hybrid sword-gun might fall into two categories. No weapon should fall into more than two categories, but selecting either one or two categories is at the discretion of the player and GM. This step has no impact on the weapon’s cost.
+Typically a weapon belongs to one category, however some weapons, such as a dagger or a hybrid sword-gun might fall into two categories. No weapon should fall into more than two categories, but selecting either one or two categories is at the discretion of the player and GM. This step has no impact on the weapon's cost.
 
 ### Step 2: Choose Properties
 
@@ -249,7 +249,7 @@ Every weapon must have either the *Forceful* or *Precise* property and some weap
 
 Next, you will may select a number of properties that have significant game impact, just like *Forceful* and *Precise*, these are listed under properties. The difference is that these other properties each have the effect of raising the Wealth Level of the weapon. The Wealth Level of all weapons begins at 1.
 
-The *Deadly* property increases an item’s Wealth Level by 2 per tier. So a *Deadly 2* item has a starting Wealth Level of 5.
+The *Deadly* property increases an item's Wealth Level by 2 per tier. So a *Deadly 2* item has a starting Wealth Level of 5.
 
 The *Defensive* property increases the Wealth Level of the item by 1 per tier, so *Defensive 3* would increase the item's Wealth Level by 3.
 
@@ -288,13 +288,13 @@ Let's build our own weapon as an example. The kusaria-gama is a very unique weap
 
 ## Mounts & Vehicles
 
-In this section, you’ll find rules for mounting upon your battle-bred warhorse or piloting your trusty old fighter ship. For mechanical purposes, mounts and vehicles are handled the same. These rules will apply whenever a character is riding upon or within another creature or object as their primary form of movement. You will move with your mount (see mount actions below), but otherwise you are considered separate for purposes of targeting, boons, banes, and similar situations.
+In this section, you'll find rules for mounting upon your battle-bred warhorse or piloting your trusty old fighter ship. For mechanical purposes, mounts and vehicles are handled the same. These rules will apply whenever a character is riding upon or within another creature or object as their primary form of movement. You will move with your mount (see mount actions below), but otherwise you are considered separate for purposes of targeting, boons, banes, and similar situations.
 
 Throughout this text, the words “mount” and “vehicle” are used interchangeably. Mechanically speaking, the rules are the same whether you are riding a pony or a star fighter, so any references to “mount” also apply to “vehicles”, and vice-versa.
 
 ### Mount Actions
 
-When mounted, you may allocate any of your actions to your mount instead of yourself. For example, while riding a velociraptor, you could spend your move action to have your raptor move 40’. Whenever your mount moves, you move with it. Likewise, instead of attacking with your own weapons, you could spend your major action to let your raptor make an attack. Your mount will have its own attributes and feats, so it will not benefit from your feats or attributes.
+When mounted, you may allocate any of your actions to your mount instead of yourself. For example, while riding a velociraptor, you could spend your move action to have your raptor move 40'. Whenever your mount moves, you move with it. Likewise, instead of attacking with your own weapons, you could spend your major action to let your raptor make an attack. Your mount will have its own attributes and feats, so it will not benefit from your feats or attributes.
 
 Typically, mounts and vehicles cannot act independently of their riders, and so they will only get to take actions when their rider allocates actions to them.
 
@@ -311,13 +311,13 @@ Detailed below are a variety of mounts and vehicles for characters to carry char
 
 **Properties** are the descriptors that make each mount unique from others. These properties translate to specific game mechanics described below.
 
-**Attributes** indicates the notable attributes possessed by the vehicle or mount. At the GM’s discretion, other attributes can be granted on an as-needed basis.
+**Attributes** indicates the notable attributes possessed by the vehicle or mount. At the GM's discretion, other attributes can be granted on an as-needed basis.
 
 **Feats** indicates the feats which the mount or vehicle possesses to highlight its unique capabilities. These feats only apply to actions taken by the mount, not actions made by the rider.
 
 **HP (Hit Points)** indicates the total hit points possessed by the vehicle or mount.
 
-**DT (Damage Threshold)** is an indication of how much punishment the mount or vehicle can take. When a vehicle reaches zero hit points, it gains one damage level and its hit points return to maximum. Any remaining damage is carried over to the it’s new hit point total, thus a vehicle can suffer multiple damage levels from a single attack if it deals enough damage. A mount has disadvantage equal to its damage level on all action rolls. Once the mount’s damage level reaches its damage threshold, it is disabled (unable to act) until healed or repaired. Repairing or healing one damage level requires 1 day per wealth level of the vehicle.
+**DT (Damage Threshold)** is an indication of how much punishment the mount or vehicle can take. When a vehicle reaches zero hit points, it gains one damage level and its hit points return to maximum. Any remaining damage is carried over to the it's new hit point total, thus a vehicle can suffer multiple damage levels from a single attack if it deals enough damage. A mount has disadvantage equal to its damage level on all action rolls. Once the mount's damage level reaches its damage threshold, it is disabled (unable to act) until healed or repaired. Repairing or healing one damage level requires 1 day per wealth level of the vehicle.
 
 **Defenses** are the Toughness, Guard, and Resolve defenses of the vehicle or mount. If "Immune" is listed for a given defense, then attacks targeting that defense have no effect.
 
@@ -326,7 +326,7 @@ Detailed below are a variety of mounts and vehicles for characters to carry char
 
 **Faster than Light** - The vehicle is capable of traveling faster than the speed of light. Doing so requires that a pilot expend a focus action on three consecutive rounds.
 
-**Guided Weapons** - Attacks made with this vehicle are particularly difficult to evade. When the vehicle makes an attack using an attribute greater than zero, it rolls an additional d20 and keeps the higher die. This benefit only applies to attacks that target an opponent’s Guard defense.
+**Guided Weapons** - Attacks made with this vehicle are particularly difficult to evade. When the vehicle makes an attack using an attribute greater than zero, it rolls an additional d20 and keeps the higher die. This benefit only applies to attacks that target an opponent's Guard defense.
 
 **Multi-Pilot** - The vehicle can be piloted by a number of people equal to the value indicated. Each pilot can make use of the vehicle to make actions, but no more than 2 move actions can be taken by the vehicle in each round.
 
@@ -343,46 +343,46 @@ Detailed below are a variety of mounts and vehicles for characters to carry char
 
 | Examples | WL | TL | Speed | Properties | Attributes | Feats | HP | DT | Defenses |
 | :----- | :-: | :-: | :-: | :-----: | :----: | :-----: | :-: | :-: | :-------- |
-| All-Terrain Jeep | 2 | 1 | 80’ | | Agility 4 | | 20 | 2 | Toughness: 14 \
+| All-Terrain Jeep | 2 | 1 | 80' | | Agility 4 | | 20 | 2 | Toughness: 14 \
 Guard: 14 \
 Resolve: Immune |
-| Battle Cruiser | 9 | 3 | 1,000’ | Faster than Light, Guided Weapons, Targeted Weapons, Independent 2, Multi-Pilot 4 | Energy 7 | Multi-Target Attack Specialist (Area) 5 | 50 | 5 | Toughness: 18 \
+| Battle Cruiser | 9 | 3 | 1,000' | Faster than Light, Guided Weapons, Targeted Weapons, Independent 2, Multi-Pilot 4 | Energy 7 | Multi-Target Attack Specialist (Area) 5 | 50 | 5 | Toughness: 18 \
 Guard: 25 \
 Resolve: Immune |
-| Drake | 5 | 0 | 50’ | Independent 1 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 38 | 1 | Toughness: 18 \
+| Drake | 5 | 0 | 50' | Independent 1 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 38 | 1 | Toughness: 18 \
 Guard: 20 \
 Resolve: 15 |
-| Fighter Ship | 5 | 3 | 2,000’ | Faster than Light, Guided Weapons, Targeted Weapons, Multi-Pilot 2 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 36 | 4 | Toughness: 15 \
+| Fighter Ship | 5 | 3 | 2,000' | Faster than Light, Guided Weapons, Targeted Weapons, Multi-Pilot 2 | Energy 6 | Multi-Target Attack Specialist (Area) 3 | 36 | 4 | Toughness: 15 \
 Guard: 22 \
 Resolve: Immune |
-| Galleon | 6 | 0 | 70’ | Targeted Weapons, Multi-Pilot 10 | Agility 6 | Multi-Target Attack Specialist (Area) 3 | 30 | 5 | Toughness: 15 \
+| Galleon | 6 | 0 | 70' | Targeted Weapons, Multi-Pilot 10 | Agility 6 | Multi-Target Attack Specialist (Area) 3 | 30 | 5 | Toughness: 15 \
 Guard: 19 \
 Resolve: Immune |
-| Griffin | 4 | 0 | 50’ | Independent 1 | Might 5 | Bane Focus (Immobile) | 34 | 1 | Toughness: 16 \
+| Griffin | 4 | 0 | 50' | Independent 1 | Might 5 | Bane Focus (Immobile) | 34 | 1 | Toughness: 16 \
 Guard: 19 \
 Resolve: 13 |
-| Horse | 3 | 0 | 40’ | | Might 4 | | 28 | 1 | Toughness: 15 \
+| Horse | 3 | 0 | 40' | | Might 4 | | 28 | 1 | Toughness: 15 \
 Guard: 15 \
 Resolve: 10 |
-| Mech Unit | 4 | 2 | 40’ | Guided Weapons, Targeted Weapons | Energy 5 \
+| Mech Unit | 4 | 2 | 40' | Guided Weapons, Targeted Weapons | Energy 5 \
 Agility 6 | Multi-Target Attack Specialist (Area) 2 | 22 | 3 | Toughness: 20 \
 Guard: 22 \
 Resolve: Immune |
-| Phoenix | 5 | 0 | 50’ | | Energy 7 | Attack Specialization II (Fire) | 32 | 1 | Toughness: 16 \
+| Phoenix | 5 | 0 | 50' | | Energy 7 | Attack Specialization II (Fire) | 32 | 1 | Toughness: 16 \
 Guard: 20 \
 Resolve: 19 |
-| Pegasus | 4 | 0 | 50’ | | Might 4 \
+| Pegasus | 4 | 0 | 50' | | Might 4 \
 Creation 4 | Boon Focus I (Heal) | 28 | 1 | Toughness: 17 \
 Guard: 18 \
 Resolve: 17 |
-| Velociraptor, Dire Wolf | 3 | 0 | 40’ | | Agility 5 \
+| Velociraptor, Dire Wolf | 3 | 0 | 40' | | Agility 5 \
 Perception 5 | Bane Focus I (Knockdown) | 24 | 1 | Toughness: 14 \
 Guard: 17 \
 Resolve: 15 |
-| T-Rex | 5 | 0 | 50’ | Independent 1 | Might 6 | Attack Specialization II (Bite) | 38 | 1 | Toughness: 15 \
+| T-Rex | 5 | 0 | 50' | Independent 1 | Might 6 | Attack Specialization II (Bite) | 38 | 1 | Toughness: 15 \
 Guard: 20 \
 Resolve: 15 |
-| Giant Scorpion | 4 | 0 | 35’ | Independent 1 | Agility 5 \
+| Giant Scorpion | 4 | 0 | 35' | Independent 1 | Agility 5 \
 Perception 5 | Bane Focus I (Persistent Damage) | 20 | 2 |  Toughness: 15 \
 Guard: 15 \
 Resolve: 18 |

--- a/core/src/05-banes-boons/01-chapter-five.md
+++ b/core/src/05-banes-boons/01-chapter-five.md
@@ -2,7 +2,7 @@
 
 Banes and boons are a huge part of what makes *Open Legend* so open. They represent the endless possibilities of effects that your character can have on other characters beyond simply dealing damage. Banes are negative conditions that you inflict upon your foes, such as by stunning them, demoralizing them, or setting them on fire. Boons are the opposite: helpful effects that assist your allies by allowing them to fly, shrug off damage, or move with extraordinary speed.
 
-Banes and boons are not tied to specific spells, attacks, or items. Any character can invoke any bane or boon as long as the character possesses the prerequisite attributes. Attribute prerequisites are meant to limit the power of banes and boons so that they scale as your character gains power. That is why, for example, your first level necromancer can invoke the *Blindsight* boon with their Entropy attribute of 5, but won’t be able to invoke the *Insubstantial* boon for themself or their allies until they gain enough experience to increase their Entropy to 7.
+Banes and boons are not tied to specific spells, attacks, or items. Any character can invoke any bane or boon as long as the character possesses the prerequisite attributes. Attribute prerequisites are meant to limit the power of banes and boons so that they scale as your character gains power. That is why, for example, your first level necromancer can invoke the *Blindsight* boon with their Entropy attribute of 5, but won't be able to invoke the *Insubstantial* boon for themself or their allies until they gain enough experience to increase their Entropy to 7.
 
 ## Telling Your Story with Banes and Boons
 
@@ -16,9 +16,9 @@ In *Open Legend*, we use the rules to make sure the game is fair and that everyo
 
 ## Invoking Banes and Boons
 
-To invoke a bane, the primary method is to succeed at an appropriate attribute roll using one of your target’s defense scores as the Challenge Rating, as indicated in the bane description. An alternate method of invoking a bane is to make a successful damaging attack that exceeds the target's defense by 10 or more. When this happens, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target. While targets may be effected by multiple banes, you may not *stack* banes; A target cannot be inflicted with a bane it is currently suffering from, unless specified in the bane's effect (*e.g.* [Fatigued](http://www.openlegendrpg.com/banes/fatigued)).
+To invoke a bane, the primary method is to succeed at an appropriate attribute roll using one of your target's defense scores as the Challenge Rating, as indicated in the bane description. An alternate method of invoking a bane is to make a successful damaging attack that exceeds the target's defense by 10 or more. When this happens, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target. While targets may be effected by multiple banes, you may not *stack* banes; A target cannot be inflicted with a bane it is currently suffering from, unless specified in the bane's effect (*e.g.* [Fatigued](http://www.openlegendrpg.com/banes/fatigued)).
 
-To invoke a boon, you must succeed at an appropriate attribute roll with a Challenge Rating determined by the boon’s Power Level. The CR equals 10 + 2 x Power Level. If a boon can be invoked at multiple Power Levels, you decide which Power Level to invoke at after making your action roll. While targets may be effected by different boons, you may not *stack* the same boon multiple times; if a second invocation of a boon would be applied to a character, they choose which boon to keep and which one to negate.
+To invoke a boon, you must succeed at an appropriate attribute roll with a Challenge Rating determined by the boon's Power Level. The CR equals 10 + 2 x Power Level. If a boon can be invoked at multiple Power Levels, you decide which Power Level to invoke at after making your action roll. While targets may be effected by different boons, you may not *stack* the same boon multiple times; if a second invocation of a boon would be applied to a character, they choose which boon to keep and which one to negate.
 
 Additional details about invoking banes and boons, such as attack range and targeting multiple creatures, can be found in Chapter 6: Combat.
 
@@ -32,7 +32,7 @@ Each bane description includes the following elements.
 
 **Attack Attributes.** This is a list of the attribute or attributes that can be used to inflict the bane. As long as you possess at least one of the listed attributes at a score greater than or equal to the Power Level, then you can inflict the bane.
 
-**Attack.** This list indicates what type of attack roll to make when inflicting the bane. Each entry consists of an attribute that the attacking player should roll and the defense score targeted by the attack. If the attacker’s roll equals or exceeds the target’s defense score, then the bane is inflicted.
+**Attack.** This list indicates what type of attack roll to make when inflicting the bane. Each entry consists of an attribute that the attacking player should roll and the defense score targeted by the attack. If the attacker's roll equals or exceeds the target's defense score, then the bane is inflicted.
 
 **Duration.** A bane typically remains in effect until the target resists it with a *Resist* roll, hence most banes have a duration of “resist ends”. If a target fails three resist rolls against a bane, the bane can no longer be resisted. It persists for an extended duration indicated in parentheses.
 
@@ -52,7 +52,7 @@ Each boon description includes the following elements.
 
 **Invocation Time.** The required time that it takes to invoke the boon. Most boons have an invocation time of 1 major action. For boons that have a longer time, you must spend the entire invocation time concentrating on nothing other than invoking the boon. If you are interrupted, you must start the casting over.
 
-**Duration.** Most boons have a duration of “sustain persists”, which indicates that the invoker must use a sustain action every round in order to keep the boon in effect. If you have a boon in effect and don’t sustain it, the boon's effects cease at the end of your turn. Because sustaining a boon is a minor action, which can only be taken once per turn, you can typically sustain only one boon at a time.
+**Duration.** Most boons have a duration of “sustain persists”, which indicates that the invoker must use a sustain action every round in order to keep the boon in effect. If you have a boon in effect and don't sustain it, the boon's effects cease at the end of your turn. Because sustaining a boon is a minor action, which can only be taken once per turn, you can typically sustain only one boon at a time.
 
 **Description.** This entry simply provides a general idea of what the boon could look like in the story.
 

--- a/core/src/06-combat/01-chapter-six.md
+++ b/core/src/06-combat/01-chapter-six.md
@@ -6,7 +6,7 @@ Sometimes, the trigger-happy gunslinger gives away your position.
 
 Sometimes, negotiations fail.
 
-That’s when combat ensues. In this chapter, you’ll learn all the rules for fighting strategic and epic battles.
+That's when combat ensues. In this chapter, you'll learn all the rules for fighting strategic and epic battles.
 
 ## When Combat Ensues
 
@@ -19,13 +19,13 @@ When the GM declares that combat will begin, the game is separated into rounds. 
 
 ### Determining Surprise
 
-In any combat, one or more combatants may be surprised if their enemy catches them off guard or unaware. For example, if a pack of bandits lays an ambush for the PCs in a rocky chasm, the GM may have every member of the party make a Perception roll contested by the bandits’ Agility roll. Any PC who fails the check is surprised. The GM decides when some or all combatants may be surprised.
+In any combat, one or more combatants may be surprised if their enemy catches them off guard or unaware. For example, if a pack of bandits lays an ambush for the PCs in a rocky chasm, the GM may have every member of the party make a Perception roll contested by the bandits' Agility roll. Any PC who fails the check is surprised. The GM decides when some or all combatants may be surprised.
 
 Surprised characters always act after non-surprised characters, as explained in the rules for initiative. Furthermore, until a surprised character takes their first turn, they may not take any interrupt actions and all attacks made against them gain advantage 1.
 
 ### Roll for Initiative
 
-After surprise has been determined, each combatant makes an Agility action roll. The total of a combatant’s Agility roll is their initiative score. The GM may decide to make one roll for each group of monsters instead of tracking every monster’s initiative individually.
+After surprise has been determined, each combatant makes an Agility action roll. The total of a combatant's Agility roll is their initiative score. The GM may decide to make one roll for each group of monsters instead of tracking every monster's initiative individually.
 
 Write down all initiative scores from highest to lowest. When taking turns in combat, characters act in order from highest initiative score to lowest. In case of ties, characters act in order of their Agility scores (from high to low). If Agility scores are also tied, determine order randomly.
 
@@ -81,18 +81,18 @@ Some GMs might love that kind of challenge, and for them, **the core mechanic ca
 | If the action roll... | then the result is... |
 | :- | :- |
 | equals or exceeds the Challenge Rating, | the player succeeds. |
-| is less than the Challenge Rating, | The GM and the PC both choose 1: <br /> -<br /> Deal 3 damage <br /> Inflict 1 bane of Power Level <= 3 <br /> Move 10’ w/o opportunity attacks |
+| is less than the Challenge Rating, | The GM and the PC both choose 1: <br /> -<br /> Deal 3 damage <br /> Inflict 1 bane of Power Level <= 3 <br /> Move 10' w/o opportunity attacks |
 
 
-With these modified rules, a player’s failed attack roll means that the player may not get what they were aiming for, but they get something. And it comes at a cost because the GM also gets to choose an effect. Remember, also, that the rules for interpreting a failed roll only apply to PCs. For the GM, a success is a success and a failure is a failure (See chapter 2 for more details).
+With these modified rules, a player's failed attack roll means that the player may not get what they were aiming for, but they get something. And it comes at a cost because the GM also gets to choose an effect. Remember, also, that the rules for interpreting a failed roll only apply to PCs. For the GM, a success is a success and a failure is a failure (See chapter 2 for more details).
 
 > ### Example of the Core Mechanic in Combat
 >
 > Vera hurls herself at the red dragon attempting to cut through his
-scaly hide. However, her attack roll fails to hit the dragon’s Guard
+scaly hide. However, her attack roll fails to hit the dragon's Guard
 of 25. She chooses to inflict 3 damage, but the GM also gets a choice.
 >
-> He chooses to inflict the knockdown bane: The dragon’s tail lashes
+> He chooses to inflict the knockdown bane: The dragon's tail lashes
 around and sweeps Vera to the floor.
 
 ### Why Succeed on a Failed Roll?
@@ -123,7 +123,7 @@ A few attributes can be used for damaging attacks in special circumstances in wh
 
 ### Probably Never
 
-The remaining attributes don’t really lend themselves to damage. Without a VERY good explanation, the following cannot be used for damaging attacks: fortitude, learning, perception, will, deception, persuasion, presence, creation, prescience.
+The remaining attributes don't really lend themselves to damage. Without a VERY good explanation, the following cannot be used for damaging attacks: fortitude, learning, perception, will, deception, persuasion, presence, creation, prescience.
 
 ## Taking Your Turn
 
@@ -168,8 +168,8 @@ To attack a foe in an attempt to damage them, follow the steps in the Attack Sum
 <div class="table-no-head"></div>
 | | |
 | - | - |
-| **Step 1: Determine Range** | **Melee** = Within your reach <br /> **Projectile** = Weapon range (Disadvantage 1 per extra range increment) <br /> **Extraordinary** <br /> &nbsp;&nbsp;&nbsp; 1 - 3 = 25’ <br /> &nbsp;&nbsp;&nbsp; 4 - 6 = 50’ <br /> &nbsp;&nbsp;&nbsp; 7 - 9 = 75’ |
-| **Step 2: Determine Targets** | *If more than one target...*  <br /> **Melee** = Disadvantage equals total # of targets <br /> **Ranged** = Disadvantage equals total # of targets (Max 5 targets within 25’ square) <br /> **Area** = Disadvantage varies (see below) |
+| **Step 1: Determine Range** | **Melee** = Within your reach <br /> **Projectile** = Weapon range (Disadvantage 1 per extra range increment) <br /> **Extraordinary** <br /> &nbsp;&nbsp;&nbsp; 1 - 3 = 25' <br /> &nbsp;&nbsp;&nbsp; 4 - 6 = 50' <br /> &nbsp;&nbsp;&nbsp; 7 - 9 = 75' |
+| **Step 2: Determine Targets** | *If more than one target...*  <br /> **Melee** = Disadvantage equals total # of targets <br /> **Ranged** = Disadvantage equals total # of targets (Max 5 targets within 25' square) <br /> **Area** = Disadvantage varies (see below) |
 | **Step 3: Determine Targeted Defense** | Weapon Attacks target Guard <br /><br /> Extraordinary Attacks target the most logical defense<br /> &nbsp;&nbsp;&nbsp;**Guard** if the attack requires dodging or deflection <br /> &nbsp;&nbsp;&nbsp;**Toughness** if the attack targets bodily health <br /> &nbsp;&nbsp;&nbsp;**Resolve** if the attack harms the psyche or will |
 | **Step 4: Roll Attack and Calculate Damage** | **Damage dealt** = Attack Roll minus Defense <br /><br />10 over defense, inflict one bane as well |
 
@@ -177,7 +177,7 @@ To attack a foe in an attempt to damage them, follow the steps in the Attack Sum
 
 **Melee weapon attacks** target foes that are within reach of you.
 
-**Projectile weapon attacks** can target foes within their range at no penalty. Attacks suffer disadvantage 1 per extra range increment beyond the first, to a maximum of disadvantage 2 at three times the weapon’s range.
+**Projectile weapon attacks** can target foes within their range at no penalty. Attacks suffer disadvantage 1 per extra range increment beyond the first, to a maximum of disadvantage 2 at three times the weapon's range.
 
 **Extraordinary attacks** have a range according to the attribute being used, as detailed in the Extraordinary Attack Range table. Unlike projectile weapons, extraordinary attacks cannot extend beyond their normal range.
 
@@ -230,14 +230,14 @@ You may choose from a variety of shapes when making an area attack as described 
 | | |
 | - | - |
 | **Melee Attacks** | Disadvantage = number of targets. |
-| **Ranged Attacks** | Disadvantage = number of targets. <br /> Max 5 targets. Must be within a 25’ square. |
-| **Cube** | Disadvantage = 1 per 5’ of length of cube. |
+| **Ranged Attacks** | Disadvantage = number of targets. <br /> Max 5 targets. Must be within a 25' square. |
+| **Cube** | Disadvantage = 1 per 5' of length of cube. |
 | **Line** | Disadvantage = 1 per 5'x10'x10' line. |
 | **Cone** | Disadvantage = 1 per 5' length of cone. |
 
 ##### 3. Determine Targeted Defense
 
-Every attack targets one of your foe’s defenses: Toughness, Guard, or Resolve.
+Every attack targets one of your foe's defenses: Toughness, Guard, or Resolve.
 
 Weapon attacks always target Guard.
 
@@ -256,12 +256,12 @@ You deal damage equal to your action roll minus the target's defense, ignoring n
 
 **Exceptional Success**
 
-If your damaging attack roll exceeds the target’s defense by 10 or more, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must
+If your damaging attack roll exceeds the target's defense by 10 or more, you may apply one bane of a Power Level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must
 equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target.
 
 #### Make a Bane Attack
 
-Instead of attempting to damage a target, you may instead choose to inflict your enemy with a bane. In order to inflict a bane, you must possess an appropriate attribute of at least the bane’s power level, as
+Instead of attempting to damage a target, you may instead choose to inflict your enemy with a bane. In order to inflict a bane, you must possess an appropriate attribute of at least the bane's power level, as
 detailed in the [*bane descriptions*](http://www.openlegendrpg.com/banes). While targets may be effected by multiple banes, you may not *stack* banes; a target cannot be inflicted with a bane it is currently suffering from, unless specified in the boon's effect (*e.g.* [Fatigued](http://www.openlegendrpg.com/banes/fatigued)).
 
 To resolve a bane attack, follow these steps:
@@ -276,7 +276,7 @@ The targeted defense is determined by the type of bane being inflicted. Consult 
 
 ##### 3. Roll Your Attack
 
-The [*bane descriptions*](http://www.openlegendrpg.com/banes) also indicate which attributes can be used to inflict each bane. Make an action roll using the appropriate attribute. If your total equals or exceeds the target’s defense score, your target suffers the bane.
+The [*bane descriptions*](http://www.openlegendrpg.com/banes) also indicate which attributes can be used to inflict each bane. Make an action roll using the appropriate attribute. If your total equals or exceeds the target's defense score, your target suffers the bane.
 
 > ##### Example Bane Attacks
 >
@@ -292,7 +292,7 @@ The [*bane descriptions*](http://www.openlegendrpg.com/banes) also indicate whic
 
 #### Invoke a Boon
 
-You can invoke boons in order to aid yourself or allies. In order to invoke a boon, you must possess an appropriate attribute of at least the boon’s power level, as detailed in the
+You can invoke boons in order to aid yourself or allies. In order to invoke a boon, you must possess an appropriate attribute of at least the boon's power level, as detailed in the
 [*boon descriptions*](http://www.openlegendrpg.com/boons). To invoke a boon, follow these steps:
 
 ##### 1. Determine Range and Target(s)
@@ -357,7 +357,7 @@ You may move up to your speed. The base speed for characters is 30'. This moveme
 
 Special movement includes climbing, jumping, swimming, and other movement that is typically more restricted than just running across the battlefield.
 
-**Jump**. Make a Might roll. If you can’t get at least a 10’ running start, you have disadvantage 1.
+**Jump**. Make a Might roll. If you can't get at least a 10' running start, you have disadvantage 1.
 
 - **For a long jump,** you cover a number of feet equal to your roll.
 - **For a high jump,** you cover a number of feet equal to your roll divided by 2.
@@ -378,7 +378,7 @@ Many banes will persist for a longer duration after three failed resist attempts
 
 ### Minor Actions
 
-Minor actions are tasks that don’t require much time or effort, but often set up larger actions. You may take any number of minor actions on your turn, but you cannot take more than one of the same type of minor action. Minor actions include the following:
+Minor actions are tasks that don't require much time or effort, but often set up larger actions. You may take any number of minor actions on your turn, but you cannot take more than one of the same type of minor action. Minor actions include the following:
 
 -   Draw or sheathe a weapon
 -   Retrieve an item stored on your person
@@ -436,7 +436,7 @@ Move up to twice your speed and make one melee attack at disadvantage 1.
 
 ### Interrupt Actions
 
-In some situations, you may want to take an action in response to another combatant’s action. In these cases, you can use an interrupt action. However, whenever you use an interrupt action, you lose your major action the next time your turn in the initiative order comes up. You can use your interrupt action to attempt any of the following:
+In some situations, you may want to take an action in response to another combatant's action. In these cases, you can use an interrupt action. However, whenever you use an interrupt action, you lose your major action the next time your turn in the initiative order comes up. You can use your interrupt action to attempt any of the following:
 
 #### Defend
 
@@ -464,7 +464,7 @@ If a feat, perk, boon, or other source grants a *Free Action*, that action can b
 
 ## Damage and Healing
 
-Your hit points (HP) are an abstract measure of your character’s ability to ignore pain, avoid deadly blows, and maintain a presence on the battlefield in spite of wounds or exhaustion. Whenever you take damage, your hit points are reduced, and whenever you receive healing they are increased.
+Your hit points (HP) are an abstract measure of your character's ability to ignore pain, avoid deadly blows, and maintain a presence on the battlefield in spite of wounds or exhaustion. Whenever you take damage, your hit points are reduced, and whenever you receive healing they are increased.
 
 ### Finishing Blows
 
@@ -484,7 +484,7 @@ Lethal damage is used sparingly in Open Legend as a way for GMs to paint a pictu
 
 A creature's maximum hit point toal is reduced by the amount of lethal damage it has sustained. The maximum lethal damage a creature can accrue is equal to its maximum hit points. If a creature sustains lethal damage greater than or equal to its maximum hit point total, the creature is unconscious until it heals at least 1 hit point of lethal damage.
 
-Lethal damage is more difficult to heal then regular damage, healing at a rate of 1 hit point per day per Fortitude attribute point (minimum of 1 hit point). With the full-time attendance of a capable healer or doctor, any number of characters who are located in the same area and avoid strenuous activity heal at an additional rate equal to their attendant’s Creation, Presence, or Learning score. Multiple attendants do not cumulatively improve this accelerated healing rate (the bonus is simply equal to the highest score among attendants).
+Lethal damage is more difficult to heal then regular damage, healing at a rate of 1 hit point per day per Fortitude attribute point (minimum of 1 hit point). With the full-time attendance of a capable healer or doctor, any number of characters who are located in the same area and avoid strenuous activity heal at an additional rate equal to their attendant's Creation, Presence, or Learning score. Multiple attendants do not cumulatively improve this accelerated healing rate (the bonus is simply equal to the highest score among attendants).
 
 For example, a warrior with Fortitude 4 heals 4 lethal damage per day on their own. With the assistance of a physician with a learning score of 8, the same warrior would heal at a rate of 12 lethal damage per day.
 

--- a/core/src/07-running-the-game/01-chapter-seven.md
+++ b/core/src/07-running-the-game/01-chapter-seven.md
@@ -1,6 +1,6 @@
 # Chapter 7: Running the Game #
 
-## The Game Master’s Calling
+## The Game Master's Calling
 
 If you're reading this chapter, then perhaps you've decided to don the most important mantle among roleplayers: that of the Game Master. Answering the call to be the GM isn't always easy, but your fellow game masters will agree that running a good campaign is perhaps the most satisfying act to be enjoyed within this fine hobby. Sure, the players get to slay dragons, amass wealth, and boast of their tales - but the GM gets to rest their head on the pillow after a late night session knowing that none of that fun would have been possible without them. The buzz of a well-run game is addicting, and we hope you'll answer the call.
 
@@ -18,7 +18,7 @@ Before we get into all of that good stuff, though, let's take a moment and explo
 
 **A good GM knows when the players are having fun.** Being a game master is an important job. It's a lot like hosting a party. For 2 to 6 hours or so, you are the primary person responsible for entertaining a group of friends. So while you are running a game, it's a good idea to take a moment, look around the room, and ask yourself *Is everyone here enjoying themselves?*
 
-**A good GM doesn't think that everyone defines fun in the same way.** As you look around the room and gauge your table’s fun, it's also important to realize that each person may come to the game for different reasons. Some just like to slay evil, others to make tactical chess-like decisions, others to tell epic stories, and still others to take on the role of realistic characters and watch them grow. Some players aren't even all that into roleplaying games, but they love the social aspect of getting together. A good GM realizes that all of these play styles are acceptable. And, while you can't please everyone all of the time you can try to make sure that everyone is having fun at some point during your games.
+**A good GM doesn't think that everyone defines fun in the same way.** As you look around the room and gauge your table's fun, it's also important to realize that each person may come to the game for different reasons. Some just like to slay evil, others to make tactical chess-like decisions, others to tell epic stories, and still others to take on the role of realistic characters and watch them grow. Some players aren't even all that into roleplaying games, but they love the social aspect of getting together. A good GM realizes that all of these play styles are acceptable. And, while you can't please everyone all of the time you can try to make sure that everyone is having fun at some point during your games.
 
 ## Creating Adventures
 
@@ -42,17 +42,17 @@ The **danger** is the bad stuff that will happen if the players don't intervene:
 
 - *The Librim Protectis has gone missing from her Majesty's University, and in it are the words of a ritual that can summon forth unfathomable evils from an alien dimension.*
 
-- *A fleet of Bogan Destroyers is sweeping the galaxy, and the players’ star system is next in their wake.*
+- *A fleet of Bogan Destroyers is sweeping the galaxy, and the players' star system is next in their wake.*
 
 All of these examples provide a real threat that needs to be taken care of by real heroes.
 
-The **motivation** is the reason that the PCs are getting involved. Sometimes the danger and motivation are wrapped up in one, but imagine how much more invested the party would be in the above scenarios if one of the children was a nephew to a player, or if the Librim went missing on the party’s watch, or if the Bogan general had murdered one of their families.
+The **motivation** is the reason that the PCs are getting involved. Sometimes the danger and motivation are wrapped up in one, but imagine how much more invested the party would be in the above scenarios if one of the children was a nephew to a player, or if the Librim went missing on the party's watch, or if the Bogan general had murdered one of their families.
 
 The **twist** in an adventure is a surprise that throws the party off course or upsets their well laid plans. Or, it could just be an exciting change of plot that makes the story deeper than the players assumed. Maybe the witch is actually the town mayor. What if the players find the Librim Protectis in the hands of a local book dealer who swears he has no idea how it fell into his hands. And perhaps the night before the Bogans are set to launch their attack, the planetary defense matrix uncovers a swarm of interdimensional space mites that have just phased into existence for no apparent reason.
 
-When planning an adventure, it’s usually fine to start with nothing more than a danger to overcome and a motivation to get the PCs invested. You can feel free to come up with a twist ahead of time, but some of the best plot twists occur as a natural result of the party’s actions.
+When planning an adventure, it's usually fine to start with nothing more than a danger to overcome and a motivation to get the PCs invested. You can feel free to come up with a twist ahead of time, but some of the best plot twists occur as a natural result of the party's actions.
 
-Once you’ve got the starting pieces of your adventure sketched out, you can decide how you want to organize your adventure. Two common frameworks are described below: the sequential adventure and the sandbox adventure.
+Once you've got the starting pieces of your adventure sketched out, you can decide how you want to organize your adventure. Two common frameworks are described below: the sequential adventure and the sandbox adventure.
 
 ### The Sequential Adventure
 
@@ -65,21 +65,21 @@ In this sort of quest, the GM plans out a logical sequence of encounters and sce
 >
 > **Events**
 >
- >1. *The Iota’s cyber response team traces the source of the attack to a small crater of a nearby moon. The PCs are dispatched to investigate and eliminate the threat while the cyber team continues its attempt to thwart the attack electronically.*
+ >1. *The Iota's cyber response team traces the source of the attack to a small crater of a nearby moon. The PCs are dispatched to investigate and eliminate the threat while the cyber team continues its attempt to thwart the attack electronically.*
 > 
 > 1. *The PCs discover a small outpost hidden within the crater. A battle with automated defense bots ensues, and the team discovers and shuts down the terminal originating the cyber attack.*
 >
-> 1. *Returning to the Iota, the PCs learn troubling information from an ensign on the cyber response team: During the life support hub-bub, a separate hack occurred in which the location of the Alliance’s secret weapon facilities was leaked. Investigation reveals that the data was taken internally, and that it hasn’t left the Iota yet.*
+> 1. *Returning to the Iota, the PCs learn troubling information from an ensign on the cyber response team: During the life support hub-bub, a separate hack occurred in which the location of the Alliance's secret weapon facilities was leaked. Investigation reveals that the data was taken internally, and that it hasn't left the Iota yet.*
 > 
-> 1. *The PCs discover that the hack came from Commander Zap’s terminal, but they don’t have enough evidence to confront him outright.*
+> 1. *The PCs discover that the hack came from Commander Zap's terminal, but they don't have enough evidence to confront him outright.*
 > 
 > 1. *Tailing Zap for a few days, they learn that he has taken a transport craft to the nearby planet Dagaan. They follow him to a secret meeting with several enemy Bogans, and a battle erupts as the PCs attempt to stop the sensitive data from entering enemy hands.*
 
-To develop a sequential adventure, you just have to plot out the most logical sequence of events that will occur based on the party’s actions. Start with a simple list like the one above. It’s best not to get too specific, lest you fall into the trap of forcing the PCs into a single direction. Instead, leave your plan loose enough to redirect it according to how your players interact with the world. For example, what if the party never puts two and two together during their investigations in event 4 above? Maybe then a second child is kidnapped a few days later, but this time there is a witness who catches a glimpse of the hag.
+To develop a sequential adventure, you just have to plot out the most logical sequence of events that will occur based on the party's actions. Start with a simple list like the one above. It's best not to get too specific, lest you fall into the trap of forcing the PCs into a single direction. Instead, leave your plan loose enough to redirect it according to how your players interact with the world. For example, what if the party never puts two and two together during their investigations in event 4 above? Maybe then a second child is kidnapped a few days later, but this time there is a witness who catches a glimpse of the hag.
 
 ### The Sandbox Adventure
 
-A sandbox is so named because, to a certain extent, the players interact with the adventure in the same way that children explore a sandbox: at their own pace and for their own reasons. In this type of adventure, there is not typically a predictable order of events. Instead, the GM populates an area with plenty of opportunities for adventure and lets the story unfold naturally based on the players’ actions and the environment’s reactions. Just like a sequential adventure, a sandbox often contains both location- and time-based events. The outline below details a sandbox adventure revolving around a valley wilderness in which a barbarian tribe skirmishes with angelic visitors from another plane.
+A sandbox is so named because, to a certain extent, the players interact with the adventure in the same way that children explore a sandbox: at their own pace and for their own reasons. In this type of adventure, there is not typically a predictable order of events. Instead, the GM populates an area with plenty of opportunities for adventure and lets the story unfold naturally based on the players' actions and the environment's reactions. Just like a sequential adventure, a sandbox often contains both location- and time-based events. The outline below details a sandbox adventure revolving around a valley wilderness in which a barbarian tribe skirmishes with angelic visitors from another plane.
 
 > #### Sample Sandbox Adventure Outline: The Scattered Souls
 >
@@ -99,7 +99,7 @@ A sandbox is so named because, to a certain extent, the players interact with th
 >
 > **Vargax Events**
 >
-> 1. *Vargax sends an emissary to the barbarians. Vargax wins over the tribe’s trust by delivering the head of a Collector.*
+> 1. *Vargax sends an emissary to the barbarians. Vargax wins over the tribe's trust by delivering the head of a Collector.*
 >
 > 1. *Vargax converts the barbarian shamans to worship him. The tribe as a whole begins transformation under demonic influence.*
 >
@@ -111,15 +111,15 @@ A sandbox is so named because, to a certain extent, the players interact with th
 >
 > 1. *With their newfound intelligence, the Collectors kidnap the son of the barbarian chief, demanding access to the burial grounds as ransom.*
 >
-> 1. *Civil war erupts within the tribe, with half of the barbarians supporting the chief’s decision to provide the ransom, and half opposing.*
+> 1. *Civil war erupts within the tribe, with half of the barbarians supporting the chief's decision to provide the ransom, and half opposing.*
 >
-> 1. *Infighting reduces the tribe’s strength significantly, allowing the Collectors to force their way into the burial grounds.*
+> 1. *Infighting reduces the tribe's strength significantly, allowing the Collectors to force their way into the burial grounds.*
 
 Developing a sandbox adventure is similar to developing a sequential one, in that you plan out the logical sequence of events. In this case, however, because the PCs have so much room for decision making, the outline differs slightly. The GM plans out all of the relevant locations to the adventure, perhaps mapping and populating them if necessary. Additionally, the GM will make a list for the key actors in the adventure. The list provides a series of events that will occur if the party does nothing to intervene.
 
-In the above example, Vargax slowly carries out his plan to infiltrate the barbarians while the Collectors are attempting to create leverage so they can avoid an all out war with the tribes. More likely than not, when the adventure actually plays out, the GM won’t end up using all of the events outlined because the party *will* do something to intervene.
+In the above example, Vargax slowly carries out his plan to infiltrate the barbarians while the Collectors are attempting to create leverage so they can avoid an all out war with the tribes. More likely than not, when the adventure actually plays out, the GM won't end up using all of the events outlined because the party *will* do something to intervene.
 
-When planning your own sandbox adventures, it’s helpful to divide the different factions involved into two categories: active and passive. You only need to create a list of events for the active factions. In the example above, the barbarians are the monkey caught in the middle, and so they are a passive faction. They don’t need their own list because the plot that unfurls around them depends on the actions of the competing factions: the Collectors and Vargax.
+When planning your own sandbox adventures, it's helpful to divide the different factions involved into two categories: active and passive. You only need to create a list of events for the active factions. In the example above, the barbarians are the monkey caught in the middle, and so they are a passive faction. They don't need their own list because the plot that unfurls around them depends on the actions of the competing factions: the Collectors and Vargax.
 
 
 ## Creating a Campaign
@@ -136,7 +136,7 @@ One of the best ways to keep a story interesting and keep yourself inspired is t
 
 - *The world is cast in an endless darkness, not because of an ancient curse as legends tell, but because human civilization was forced underground eons ago. No one has ever discovered the “roof” of the world, so they assume that the sun is dead.*
 
-- *A world tree is the source of the planet’s life. When it dies, the world will not die, but instead be reborn in a new form.
+- *A world tree is the source of the planet's life. When it dies, the world will not die, but instead be reborn in a new form.
 Every intelligent being is tied to an invisible spirit. A very few sinister mages, known as the Warlocks, have discovered how to see and bargain with these spirits in order to manipulate the world to their advantage.*
 
 - *The galactic empress who sits on the throne has a twin sister who was cast out and left for dead at birth because she was prophesied to lead the galaxy to ruin. The twin survived, raised by an evil alien entity, and she will soon return to claim the half of the empire that is her birthright.*
@@ -165,7 +165,7 @@ Like most of the steps laid out in this guide to GMing, your campaign arcs shoul
 
 ### Plan Enough to Get Started
 
-Once you’ve got your secret and arcs written down, the final step is to plan out enough to get you started. Develop the maps, NPCs, factions, and other elements that you need to get the party through their first couple of adventures. Resist the urge to make everything perfect and plan for every possible player action.
+Once you've got your secret and arcs written down, the final step is to plan out enough to get you started. Develop the maps, NPCs, factions, and other elements that you need to get the party through their first couple of adventures. Resist the urge to make everything perfect and plan for every possible player action.
 
 And start with what you love to do. The GM has a big job, so stick to developing the campaign elements that excite you. Some GMs can spend an afternoon drawing an entire world map, and the act of creating that world inspires them with an infinite number of dungeons, plotlines, and adventures to keep the players happy for a year. Other GMs start with a list of NPCs or factions, thinking through their motivations and personalities. Creating this cast of characters allows them to imagine a host of conflicts and conspiracies that will naturally transform into dramatic encounters once the PCs are thrown into the mix. Still other game masters love to start with memorable combat encounters and action scenes, and connect the dots of plot and setting as these epic battles take shape. Whatever aspect of GMing interests you the most, that is where you should start.
 
@@ -177,7 +177,7 @@ The thrill of adventure, the satisfaction of character development, and the joy 
 
 In Open Legend, the primary way that players gain more power is by gaining experience points (XP) and reaching higher character levels, thus increasing their attribute scores and unlocking new feats, banes, and boons. Every XP that players receive grants them 1 feat point and 3 attribute points, and every 3 XP results in a new level.
 
-Rather than constantly awarding different experience point values to different monsters or types of challenges, Open Legend uses a very simple method of determining when players level up: the GM. That’s right. You get to decide when your players gain more power. Here are two methods you can use to decide how to award XP:
+Rather than constantly awarding different experience point values to different monsters or types of challenges, Open Legend uses a very simple method of determining when players level up: the GM. That's right. You get to decide when your players gain more power. Here are two methods you can use to decide how to award XP:
 
 **Big Milestones.** You could award a new level whenever the players complete a major quest, defeat a powerful foe, or neutralize a serious threat. With this method, you may want to plan out the big milestones that you can foresee being accomplished in your campaign. Whenever your players reach one of these milestones, you give them 3 XP and thus a new level. A milestone map might look something like this:
 
@@ -185,7 +185,7 @@ Rather than constantly awarding different experience point values to different m
 
 - **Level 3:** The heroes discover the Cult of the Dragon.
 
-- **Level 4:** The heroes prevent the cult’s Ritual of Three
+- **Level 4:** The heroes prevent the cult's Ritual of Three
   from being completed.
 
 - **Level 5:** The heroes retrieve the treasure at the bottom of the Sunken Star.
@@ -196,23 +196,23 @@ Rather than constantly awarding different experience point values to different m
 
 - **Level 8:** The heroes discover the secret of the Ruins of Mastika.
 
-- **Level 9:** The heroes find a way to weaken Dezzer Kai’s power over the land.
+- **Level 9:** The heroes find a way to weaken Dezzer Kai's power over the land.
 
 - **Level 10:** The heroes defeat Dezzer Kai.
 
 
-**Time Played.** An easy way to schedule rewards is simply to give players 1 XP at the end of each session. This way, they’ll always look forward to gaining that little extra bit of power that comes from attributes and feats. Occasionally, you may decide to switch it up a bit and award players with 2 or even 3 XP if they accomplished a particularly important goal. With this method, you don’t have to plan out a campaign’s milestones ahead of time, but you may need to adapt on the fly to your players' increasing power.
+**Time Played.** An easy way to schedule rewards is simply to give players 1 XP at the end of each session. This way, they'll always look forward to gaining that little extra bit of power that comes from attributes and feats. Occasionally, you may decide to switch it up a bit and award players with 2 or even 3 XP if they accomplished a particularly important goal. With this method, you don't have to plan out a campaign's milestones ahead of time, but you may need to adapt on the fly to your players' increasing power.
 
 ##### Beyond 10th Level
 
-Although officially, Open Legend was designed with a maximum character level of 10, there is no reason you can’t extend your campaign beyond this threshold if you are up for the challenge (higher level characters can be difficult to manage and properly engineer challenges for). Feel free to continue the campaign for as many levels as is fun for both you and your players. To do so, simply continue the established progression of 3 XP to gain a new level, with each XP also providing 1 feat point and 3 attribute points.
+Although officially, Open Legend was designed with a maximum character level of 10, there is no reason you can't extend your campaign beyond this threshold if you are up for the challenge (higher level characters can be difficult to manage and properly engineer challenges for). Feel free to continue the campaign for as many levels as is fun for both you and your players. To do so, simply continue the established progression of 3 XP to gain a new level, with each XP also providing 1 feat point and 3 attribute points.
 
 
 #### All That Glitters: Giving Players More Wealth
 
 In addition to power, most players enjoy being able to have more influence on the campaign world by amassing hoards of treasure. With money comes the ability to buy better equipment, employ hirelings, construct fortifications, and even raise armies.
 
-Chapter 4 explains Open Legend’s simplified wealth system, and the Wealth Overview Table indicates the typical wealth score of PCs at varying experience levels. Players start with a wealth score of 2 and it will increase whenever the GM decides. Just as experience levels represent a vast increase in power, new wealth scores drastically improve the players’ access to valuable goods. A character who goes from wealth 3 to 4, for example, has progressed from being able to purchase a fine horse to being able to buy a siege engine.
+Chapter 4 explains Open Legend's simplified wealth system, and the Wealth Overview Table indicates the typical wealth score of PCs at varying experience levels. Players start with a wealth score of 2 and it will increase whenever the GM decides. Just as experience levels represent a vast increase in power, new wealth scores drastically improve the players' access to valuable goods. A character who goes from wealth 3 to 4, for example, has progressed from being able to purchase a fine horse to being able to buy a siege engine.
 
 <div class="table-no-body"></div>
 | Wealth Overview |
@@ -226,28 +226,28 @@ Chapter 4 explains Open Legend’s simplified wealth system, and the Wealth Over
 | 2 | skilled laborer, town guardsman, 1st level hero | martial weapons, scale mail armor, a good horse, a raft |
 | 3 | master artisan, village mayor | full plate armor, silver weapons, a small boat, a fine horse |
 | 4 | 4th level hero, noble, city mayor | elven full plate, a small ship, a siege engine |
-| 5 | lord of a realm, thieves’ guild master in a large city | a large cargo ship, a city wall |
+| 5 | lord of a realm, thieves' guild master in a large city | a large cargo ship, a city wall |
 | 6 | 7th level hero | a large warship |
 | 7 | king | a stronghold, startup funding for a new town |
 | 8 | 10th level hero | startup funding for a new city, an army of 10,000 |
 | 9 | emperor| a castle, an army of 50,000 |
 
 
-You can use this table as a rough guideline for when to give players more wealth, particularly if you have also created an outline of milestones for granting experience levels. For example, the table shows that by 4th level, a typical character should have progressed to wealth score 4. Using the experience level milestone plan detailed previously, we could decide that after stopping the first threat to Woodshold, the people of the town take up a collection to reward the heroes. We can also plan to give the Cult of the Dragon a horde of treasure that will again increase the party’s wealth score.
+You can use this table as a rough guideline for when to give players more wealth, particularly if you have also created an outline of milestones for granting experience levels. For example, the table shows that by 4th level, a typical character should have progressed to wealth score 4. Using the experience level milestone plan detailed previously, we could decide that after stopping the first threat to Woodshold, the people of the town take up a collection to reward the heroes. We can also plan to give the Cult of the Dragon a horde of treasure that will again increase the party's wealth score.
 
-However you plan to award wealth, you can see that the general recommendation on the table is for a PC’s wealth score to increase twice every three levels.
+However you plan to award wealth, you can see that the general recommendation on the table is for a PC's wealth score to increase twice every three levels.
 
-If you or your players have a background with other game systems, in which they may have regularly looted every corpse, scavenged every piece of equipment, and dutifully tracked every single gold piece, then Open Legend’s wealth system might initially feel a bit awkward. If it does, consider some of the following tips:
+If you or your players have a background with other game systems, in which they may have regularly looted every corpse, scavenged every piece of equipment, and dutifully tracked every single gold piece, then Open Legend's wealth system might initially feel a bit awkward. If it does, consider some of the following tips:
 
-**NPCs still have stuff on them.** Just because you don’t need to spend hours tracking every piece of loot that the players cut from a corpse doesn’t mean that they don’t have stuff on them. It just fades into the background so that you can focus on the story.
+**NPCs still have stuff on them.** Just because you don't need to spend hours tracking every piece of loot that the players cut from a corpse doesn't mean that they don't have stuff on them. It just fades into the background so that you can focus on the story.
 
-Think of any movie or novel. How often does the action focus on the characters picking at the defeated bodies of the antagonists? Rarely. And, if they do take something from a foe, it’s usually to serve the plot.
+Think of any movie or novel. How often does the action focus on the characters picking at the defeated bodies of the antagonists? Rarely. And, if they do take something from a foe, it's usually to serve the plot.
 
-So, when a combat encounter ends, instead of listing off how many crossbow bolts each bandit has on them, just tell the party that they find a few valuables to add to their ever-growing stash, but that it’s still not enough to increase their wealth score. If a player does legitimately need another clip of ammo or another dagger or a new cloak, then you can decide whether or not it makes sense for the NPCs to have them.
+So, when a combat encounter ends, instead of listing off how many crossbow bolts each bandit has on them, just tell the party that they find a few valuables to add to their ever-growing stash, but that it's still not enough to increase their wealth score. If a player does legitimately need another clip of ammo or another dagger or a new cloak, then you can decide whether or not it makes sense for the NPCs to have them.
 
-**Wealth represents influence.** Since players aren’t tracking individual gold pieces, dollars, or gems, situations like bribery might initially prove to be a bit sticky. But a good guideline is that a character can easily use money to influence someone else of a lower wealth score.
+**Wealth represents influence.** Since players aren't tracking individual gold pieces, dollars, or gems, situations like bribery might initially prove to be a bit sticky. But a good guideline is that a character can easily use money to influence someone else of a lower wealth score.
 
-If the recipient of the bribe has the **same wealth score** as the character, then it would be considered a “major expense”, which means that it can be done, but the expense taxes resources such that new goods at that level or higher can’t be acquired for two weeks. If the bribe recipient is **one wealth level higher** than the character’s Wealth Score, the cost is so great that the character’s Wealth Score is permanently reduced by 1. Bribing someone more than one Wealth level higher is impossible without other factors in play.
+If the recipient of the bribe has the **same wealth score** as the character, then it would be considered a “major expense”, which means that it can be done, but the expense taxes resources such that new goods at that level or higher can't be acquired for two weeks. If the bribe recipient is **one wealth level higher** than the character's Wealth Score, the cost is so great that the character's Wealth Score is permanently reduced by 1. Bribing someone more than one Wealth level higher is impossible without other factors in play.
 
 So, a character with a wealth score of 2 will be inconvenienced in bribing a town guard, and a character probably needs a wealth score of 5 before they can easily bribe powerful political figures like the town mayor.
 
@@ -265,7 +265,7 @@ No campaign or adventure is complete without monsters for the heroes to defeat o
 
 ### Henchmen
 
-Henchman is a general term to describe any antagonist who simply exists as a small obstacle to the party’s short term plans. Examples of henchmen include a wandering band of space pirates that waylays the party mid-flight, a mindless ooze roaming the deep corners of a cavernous dungeon, and a team of assassins dispatched by the local mob boss to put an end to the heroes’ meddling. While henchmen typically have realistic motives, their influence on the plot is small enough that you don’t need to spend as much energy to make your henchmen deep and convincing. The orcs are motivated by greed, the ooze by hunger, and the assassins by loyalty to their guild.
+Henchman is a general term to describe any antagonist who simply exists as a small obstacle to the party's short term plans. Examples of henchmen include a wandering band of space pirates that waylays the party mid-flight, a mindless ooze roaming the deep corners of a cavernous dungeon, and a team of assassins dispatched by the local mob boss to put an end to the heroes' meddling. While henchmen typically have realistic motives, their influence on the plot is small enough that you don't need to spend as much energy to make your henchmen deep and convincing. The orcs are motivated by greed, the ooze by hunger, and the assassins by loyalty to their guild.
 
 ### Villains
 
@@ -273,37 +273,37 @@ The villain of a plotline is the primary antagonist, and your players will likel
 
 **Motive.** Every villain should have a realistic motive, or a reason for turning towards their villainous ways. Instead of deciding that your necromancer is simply evil, for example, consider making them fallen. Perhaps they turned to necromancy as a last resort to revive their beloved partner who was killed in a shipwreck.
 
-**Scheme.** Your villain’s scheme is the evil deed they have set out to complete. The scheme is often tied directly to the motive. For example, rather than the necromancer simply being set on snuffing the life out of the town, their scheme involves sacrificing ten villagers as part of a ritual to return their partner to life.
+**Scheme.** Your villain's scheme is the evil deed they have set out to complete. The scheme is often tied directly to the motive. For example, rather than the necromancer simply being set on snuffing the life out of the town, their scheme involves sacrificing ten villagers as part of a ritual to return their partner to life.
 
-**Flaw.** A flaw is part of what makes a villain human (even if the villain is an ancient wyrm). A flaw could be a physical vulnerability, such as the bare patch of Smaug’s left breast, or it could be a social, mental, or emotional insufficiency. Our necromancer, for example, could be easily set into a blind rage against anyone who speaks ill of their beloved.
+**Flaw.** A flaw is part of what makes a villain human (even if the villain is an ancient wyrm). A flaw could be a physical vulnerability, such as the bare patch of Smaug's left breast, or it could be a social, mental, or emotional insufficiency. Our necromancer, for example, could be easily set into a blind rage against anyone who speaks ill of their beloved.
 
 ### Allies
 
-NPCs aren’t limited to antagonists, of course. Many of the most important characters to your plotline will be allies of the heroes. Perhaps the party is guided by a wisened sage who secludes himself in a high tower and for unknown reasons allows only the PCs access to his wisdom. Another example includes a team of native elves who have been dispatched to see the heroes safely through a haunted wood.
+NPCs aren't limited to antagonists, of course. Many of the most important characters to your plotline will be allies of the heroes. Perhaps the party is guided by a wisened sage who secludes himself in a high tower and for unknown reasons allows only the PCs access to his wisdom. Another example includes a team of native elves who have been dispatched to see the heroes safely through a haunted wood.
 
-Whatever sorts of allies the party has acquired, it’s important for the GM to abide by a few guidelines to ensure that the allies add to the fun rather than detract from it.
+Whatever sorts of allies the party has acquired, it's important for the GM to abide by a few guidelines to ensure that the allies add to the fun rather than detract from it.
 
-**Allies should empower the heroes, not outshine them.** Effective allies provide the players with the power or opportunity to achieve even greater deeds. To put it another way, the allies should help the party shine rather than take the spotlight for themselves. Players want to be the main characters of their story, so it’s important to avoid the temptation to make your NPCs the center of attention. Although these tactics might work in some situations, you should generally shy away from the following:
+**Allies should empower the heroes, not outshine them.** Effective allies provide the players with the power or opportunity to achieve even greater deeds. To put it another way, the allies should help the party shine rather than take the spotlight for themselves. Players want to be the main characters of their story, so it's important to avoid the temptation to make your NPCs the center of attention. Although these tactics might work in some situations, you should generally shy away from the following:
 
 - Allowing an NPC to sweep in and save the day.
 
 - Having an NPC be the primary damage dealer in a fight.
 
-- Creating situations in which the players feel forced to take an NPC’s orders or advice.
+- Creating situations in which the players feel forced to take an NPC's orders or advice.
 
 There are no hard and fast rules, however. If you find NPCs in your game frequently doing the above, then there's a good chance your players might become frustrated.
 
-But sometimes it can add to the story to have an ally contribute in a way that the players can't, but it's important to find some purpose for the players to fulfill that the NPC can't for one reason or another. For example, a powerful mad scientist uses a poisonous gas to control the minds of a group of soldiers and commands them to attack the players. A powerful ally NPC might use his medical knowledge to create an anti-toxin to protect the minds of the players by breaking the influence over them and half of the soldiers. However, the NPC isn’t capable of providing this protection for all of the soldiers - the players must then complete the vital task of subduing (ideally without killing) the dominated soldiers and preventing them from harming anyone.
+But sometimes it can add to the story to have an ally contribute in a way that the players can't, but it's important to find some purpose for the players to fulfill that the NPC can't for one reason or another. For example, a powerful mad scientist uses a poisonous gas to control the minds of a group of soldiers and commands them to attack the players. A powerful ally NPC might use his medical knowledge to create an anti-toxin to protect the minds of the players by breaking the influence over them and half of the soldiers. However, the NPC isn't capable of providing this protection for all of the soldiers - the players must then complete the vital task of subduing (ideally without killing) the dominated soldiers and preventing them from harming anyone.
 
-The above example will likely be an intriguing scene enjoyed by all, because the ally NPC can’t prevail without the help of the players.
+The above example will likely be an intriguing scene enjoyed by all, because the ally NPC can't prevail without the help of the players.
 
-**Allies can be used to grant knowledge.** In addition to providing players with new power, allies can also be the purveyors of information. A savvy merchant knows how to gain leverage on the members of the trader’s guild; a pitiful sanitation clerk turned wererat possesses the only known map of the city sewers; a sage who acts as patron to the party has discovered the location of the Universe Portal. By using allies to inform the players of secret or hidden knowledge, you put the power of what to do with that information in the PCs’ hands.
+**Allies can be used to grant knowledge.** In addition to providing players with new power, allies can also be the purveyors of information. A savvy merchant knows how to gain leverage on the members of the trader's guild; a pitiful sanitation clerk turned wererat possesses the only known map of the city sewers; a sage who acts as patron to the party has discovered the location of the Universe Portal. By using allies to inform the players of secret or hidden knowledge, you put the power of what to do with that information in the PCs' hands.
 
-**Allies should be imperfect.** The best allies are the ones who are flawed just like the PCs. They have physical weaknesses that can be taken advantage of, moral faults that can be exploited, or needs that they can’t fulfill on their own. If the allies are so powerful that no mortal can stop them and they want for nothing, the players are likely to wonder why the NPC is giving them the time of day in the first place, and, by finding ways to demonstrate your NPCs’ imperfections, you'll further immerse your players in the fantasy.
+**Allies should be imperfect.** The best allies are the ones who are flawed just like the PCs. They have physical weaknesses that can be taken advantage of, moral faults that can be exploited, or needs that they can't fulfill on their own. If the allies are so powerful that no mortal can stop them and they want for nothing, the players are likely to wonder why the NPC is giving them the time of day in the first place, and, by finding ways to demonstrate your NPCs' imperfections, you'll further immerse your players in the fantasy.
 
 ### Monsters and NPC Statistics
 
-Many of the monsters and NPCs that the PCs encounter throughout their journey will be used solely for the purposes of role playing or setting the mood. These sort of background characters typically don’t need a full array of attributes, feats, and favored banes because, more likely than not, you’ll never make a single action roll for them. Angus the Blacksmith, for example, might spice up the town bazaar a bit with his Scottish accent and epic tales of fraudulent accomplishments - but your party is never going to need to engage him in combat.
+Many of the monsters and NPCs that the PCs encounter throughout their journey will be used solely for the purposes of role playing or setting the mood. These sort of background characters typically don't need a full array of attributes, feats, and favored banes because, more likely than not, you'll never make a single action roll for them. Angus the Blacksmith, for example, might spice up the town bazaar a bit with his Scottish accent and epic tales of fraudulent accomplishments - but your party is never going to need to engage him in combat.
 
 A good deal of your monsters and NPCs, however, will require statistical descriptions to use for combat or social encounters. This section will describe two ways that you can build these statistics: the complex build and the simple build.
 
@@ -311,11 +311,11 @@ A good deal of your monsters and NPCs, however, will require statistical descrip
 
 When designing an NPC using the complex build, you simply create the NPC as if it was a player character. Select an appropriate level and use the instructions in chapter one to assign attributes, feats, and other defining characteristics.
 
-The complex build is a good option when you are creating a very important villain or ally who will play a major role in the story line. This process can take a while, so it’s not worth going through with underlings, henchmen, or beasts who are only going to be present for a single scene.
+The complex build is a good option when you are creating a very important villain or ally who will play a major role in the story line. This process can take a while, so it's not worth going through with underlings, henchmen, or beasts who are only going to be present for a single scene.
 
 #### Simple Build
 
-The simple build option is useful when you need to come up with statistics on the fly. For example, imagine the party fails an action roll to move stealthily through a swamp to avoid the local denizens. You decide that they have attracted the attention of a handful of poisonous serpents that lair in the swamp, but you don’t have any stats written up for these monsters. In this situation, you could use the simple build rules to get combat rolling quickly.
+The simple build option is useful when you need to come up with statistics on the fly. For example, imagine the party fails an action roll to move stealthily through a swamp to avoid the local denizens. You decide that they have attracted the attention of a handful of poisonous serpents that lair in the swamp, but you don't have any stats written up for these monsters. In this situation, you could use the simple build rules to get combat rolling quickly.
 
 
 <div class="table-no-body"></div>
@@ -337,7 +337,7 @@ The simple build option is useful when you need to come up with statistics on th
 | 10 | 28 - 40 | 19 - 25 | 9 | 7 |
 
 
-Use the NPC Simple Build Table to determine the monster’s most relevant statistics. For the hit point and defense columns, choose values within the given ranges based on the strengths and weaknesses of the monster you are building. Choose 1 to 3 primary attributes that will form the main basis of the monster’s attacks and actions, and then choose as many secondary attributes as you need in order to define the monster’s other capabilities.
+Use the NPC Simple Build Table to determine the monster's most relevant statistics. For the hit point and defense columns, choose values within the given ranges based on the strengths and weaknesses of the monster you are building. Choose 1 to 3 primary attributes that will form the main basis of the monster's attacks and actions, and then choose as many secondary attributes as you need in order to define the monster's other capabilities.
 
 Once you have the basic statistics recorded, choose a few of the following feats to provide your monster with special attacks and abilities:
 
@@ -406,7 +406,7 @@ You may use your attacks to make any combination of bane or damaging attacks, bu
 
 > #### Example Simple Monster Build: Swamp Snakes
 >
-> Returning to the example at the beginning of this section, let’s build our venomous swamp snakes imagining that the party is made up of 3rd level characters, and thus we choose to make the Swamp Snakes using the row for level 3 Monsters. We decide that the snakes aren’t particularly tough to kill, so referencing the Simple Build Table, we’ll give them the low end of the suggested range and settle on 14 hit points each. When it comes to defenses, snakes are fast, mildly sturdy, and weak willed. So, we’ll go with the high range for Guard: 18, the middle range for Toughness: 15, and the low range for Resolve: 12. We’ll only assign one primary attribute, giving the snakes an Agility of 5, and we’ll assign Perception, Fortitude, and Deception as secondary attributes with a score of 4.
+> Returning to the example at the beginning of this section, let's build our venomous swamp snakes imagining that the party is made up of 3rd level characters, and thus we choose to make the Swamp Snakes using the row for level 3 Monsters. We decide that the snakes aren't particularly tough to kill, so referencing the Simple Build Table, we'll give them the low end of the suggested range and settle on 14 hit points each. When it comes to defenses, snakes are fast, mildly sturdy, and weak willed. So, we'll go with the high range for Guard: 18, the middle range for Toughness: 15, and the low range for Resolve: 12. We'll only assign one primary attribute, giving the snakes an Agility of 5, and we'll assign Perception, Fortitude, and Deception as secondary attributes with a score of 4.
 >
 > When it comes to feats, we decide to highlight the danger of the venom by choosing Multi Bane Specialist and Bane Focus to allow the snakes to inflict both the stunned and persistent damage banes whenever they land a damaging attack that exceeds the target's defense by 5 or more.
 
@@ -414,7 +414,7 @@ You may use your attacks to make any combination of bane or damaging attacks, bu
 
 A Boss is a single monster or NPC that is capable of taking on a group of characters due to extraordinary prowess in combat. Bosses could be epic villains that the party has been pursuing for the entire campaign, such as the Lich King Akrakus, or they could be monstrous beasts with little backstory that simply serve as a dramatic milestone in the course of a larger adventure, such as a bridge troll that must be defeated before the PCs can progress. Other examples of bosses include the Kraken, a legendary gunslinger, a dragon, or the general of an alien armada.
 
-When you decide that one of your monsters or NPCs merits boss status, use the Boss Monster Build Table to generate statistics in the same way you would if using the simple build rules described previously. You’ll notice that bosses have more hit points, higher defenses, and better attributes in order to account for their ability to take on entire parties of PCs alone. When using the complex build, you can alter your villain’s hit points and defenses based on this table to better represent the appropriate strength of a boss.
+When you decide that one of your monsters or NPCs merits boss status, use the Boss Monster Build Table to generate statistics in the same way you would if using the simple build rules described previously. You'll notice that bosses have more hit points, higher defenses, and better attributes in order to account for their ability to take on entire parties of PCs alone. When using the complex build, you can alter your villain's hit points and defenses based on this table to better represent the appropriate strength of a boss.
 
 
 <div class="table-no-body"></div>
@@ -437,9 +437,9 @@ When you decide that one of your monsters or NPCs merits boss status, use the Bo
 
 **Boss Actions**
 
-In addition to its normal allotment of actions, a boss will also receive one or more boss actions on its turn. When rolling initiative for a boss, make an extra number of initiative rolls for each boss action. When arranging the initiative order, there must be at least one PC between each of the boss’s turns. If necessary, move the “boss action” turns lower in the order to accommodate this requirement.
+In addition to its normal allotment of actions, a boss will also receive one or more boss actions on its turn. When rolling initiative for a boss, make an extra number of initiative rolls for each boss action. When arranging the initiative order, there must be at least one PC between each of the boss's turns. If necessary, move the “boss action” turns lower in the order to accommodate this requirement.
 
-During combat, the boss monster’s highest initiative count indicates its normal turn, during which it gets the usual allotment of major, move, and minor actions. Each of the boss’s lower counts in the initiative are boss actions, which allow the boss to make one major action.
+During combat, the boss monster's highest initiative count indicates its normal turn, during which it gets the usual allotment of major, move, and minor actions. Each of the boss's lower counts in the initiative are boss actions, which allow the boss to make one major action.
 
 ## Planning Combat Encounters
 
@@ -447,7 +447,7 @@ The build rules just explained help you create individual monsters or NPCs for t
 
 ### Encounter Difficulty
 
-When designing a combat encounter, decide if you want it to be easy, moderate, or hard. An **easy encounter** shouldn’t present a significant threat to the PCs unless luck is wildly against them or they make a series of poor decisions. A **moderate encounter** will challenge the PCs, but they are still likely to come out on top. A **hard encounter** will push them to the limits, and may end in defeat or the death of one or more characters.
+When designing a combat encounter, decide if you want it to be easy, moderate, or hard. An **easy encounter** shouldn't present a significant threat to the PCs unless luck is wildly against them or they make a series of poor decisions. A **moderate encounter** will challenge the PCs, but they are still likely to come out on top. A **hard encounter** will push them to the limits, and may end in defeat or the death of one or more characters.
 
 Use the Encounter Difficulty Table to determine how many total monster levels you should include in your combat.
 
@@ -489,25 +489,25 @@ Rarely do epic movie fight scenes take place in an empty chamber. There are usua
 
 ### Encounter Consequences
 
-Not every fight that your party gets into needs to be a knock down drag out fight to the death, nor does every encounter need to have a binary win/loss condition. When determining how a fight ends, remember to consider the motivations of the combatants and the demands of the plot. Are the PCs worth more to the orc chief alive than dead? Will the story be more interesting if the dragon doesn’t wipe out the entire party? Consider some of the following possibilities whenever deciding how a fight will end.
+Not every fight that your party gets into needs to be a knock down drag out fight to the death, nor does every encounter need to have a binary win/loss condition. When determining how a fight ends, remember to consider the motivations of the combatants and the demands of the plot. Are the PCs worth more to the orc chief alive than dead? Will the story be more interesting if the dragon doesn't wipe out the entire party? Consider some of the following possibilities whenever deciding how a fight will end.
 
-**Don’t be afraid to end it early.** Sometimes, despite all your plans, a combat just takes too long. Or maybe the party’s luck runs dry and they spend four rounds trying to kill the last two carnivorous shrubs. It’s okay to fast-forward the combat when things are going stale and everyone at the table is ready for the next scene. Simply narrate the gist of what happens, and move on. Generally, you should only do this if the combat is obviously going to end in the PCs’ favor. If the bad guys are winning, most parties will likely want to fight to the bitter end. If fast-forwarding to a party defeat, be sure that ALL of your players are agreeable first.
+**Don't be afraid to end it early.** Sometimes, despite all your plans, a combat just takes too long. Or maybe the party's luck runs dry and they spend four rounds trying to kill the last two carnivorous shrubs. It's okay to fast-forward the combat when things are going stale and everyone at the table is ready for the next scene. Simply narrate the gist of what happens, and move on. Generally, you should only do this if the combat is obviously going to end in the PCs' favor. If the bad guys are winning, most parties will likely want to fight to the bitter end. If fast-forwarding to a party defeat, be sure that ALL of your players are agreeable first.
 
 **Partial defeat is more interesting than a total party kill.** Battles are much greater swirling maelstroms of chaos than our gridded battle mats, top-down views, and sequential turns would lead us to believe. This means that the GM has plenty of wiggle room for creating outcomes that might not have come up in the blow-by-blow narrative of the encounter. So, if the entire party is knocked unconscious or otherwise defeated, you are well within your rights to say that, for example, one of the PCs stumbled out of sight unnoticed before passing out, or that the monsters leave half of the party for dead and capture the few that they think are still alive. Little twists like this allow the players a chance to turn a loss into an epic tale for revenge or recovery.
 
-**Hard decisions test a hero’s mettle.** A favorite tactic of super villains everywhere is to force the hero to decide between winning the fight or saving a mass of helpless bystanders. Combat encounters in Open Legend can also end in tough decisions for the party: the sorcerer hovers over a magma filled chasm so that landing the final blow also means destroying the magical staff he wields, the hill giant reveals that he has a family captive in a cave which he will only reveal if his life is spared, and so on. Though your players will get tired of these tactics if they are used excessively, forcing hard choices on your heroes will help them define their characters and prove their loyalties.
+**Hard decisions test a hero's mettle.** A favorite tactic of super villains everywhere is to force the hero to decide between winning the fight or saving a mass of helpless bystanders. Combat encounters in Open Legend can also end in tough decisions for the party: the sorcerer hovers over a magma filled chasm so that landing the final blow also means destroying the magical staff he wields, the hill giant reveals that he has a family captive in a cave which he will only reveal if his life is spared, and so on. Though your players will get tired of these tactics if they are used excessively, forcing hard choices on your heroes will help them define their characters and prove their loyalties.
 
-**Death is okay, sometimes.** The above suggestions aren’t meant to imply that you should never kill off a PC (or four). They are simply illustrations of the variety of ways that a fight can end in an interesting manner. Sometimes, heroes die, and if your players know that character death is a real possibility, it will make their victories and exploits all the more legendary. If a character does need to die, though, make sure they go out with a bang, with an epic story to be sung by bards for ages eternal.
+**Death is okay, sometimes.** The above suggestions aren't meant to imply that you should never kill off a PC (or four). They are simply illustrations of the variety of ways that a fight can end in an interesting manner. Sometimes, heroes die, and if your players know that character death is a real possibility, it will make their victories and exploits all the more legendary. If a character does need to die, though, make sure they go out with a bang, with an epic story to be sung by bards for ages eternal.
 
 ### On Balance and Fairness
 
 When planning your encounters, you do not need to strive for balance, but you should aim to be fair to your players.
 
-Video games are balanced: they are designed to present players with incremental challenges that grow in difficulty alongside the power of the player. Because of the inherent lack of openness and choice in most video games, players would easily get frustrated if the challenges weren’t balanced to their progress in the game.
+Video games are balanced: they are designed to present players with incremental challenges that grow in difficulty alongside the power of the player. Because of the inherent lack of openness and choice in most video games, players would easily get frustrated if the challenges weren't balanced to their progress in the game.
 
-Role playing games, on the other hand, aren’t meant to be balanced all of the time. They are meant to be immersive. They are meant to allow players to push the limits of possibility in fantastical worlds. This level of freedom means that sometimes the heroes will come face to face with threats that they cannot overcome.
+Role playing games, on the other hand, aren't meant to be balanced all of the time. They are meant to be immersive. They are meant to allow players to push the limits of possibility in fantastical worlds. This level of freedom means that sometimes the heroes will come face to face with threats that they cannot overcome.
 
-As a GM, you don’t need to have any anxiety over putting an impossible challenge before your party. But you do have to be fair about it. You are responsible for warning the party to the danger that lies ahead. It would be unfair, for example, to drop an ancient red wyrm upon an unsuspecting party of first level PCs with no option to escape. It would be perfectly fair, however, if the party encounters the dragon after exploring the ancient ruins that make his lair despite warnings from the locals and tremors that grow stronger with every step deeper into the ruins.
+As a GM, you don't need to have any anxiety over putting an impossible challenge before your party. But you do have to be fair about it. You are responsible for warning the party to the danger that lies ahead. It would be unfair, for example, to drop an ancient red wyrm upon an unsuspecting party of first level PCs with no option to escape. It would be perfectly fair, however, if the party encounters the dragon after exploring the ancient ruins that make his lair despite warnings from the locals and tremors that grow stronger with every step deeper into the ruins.
 
 ### Ad Hoc Damage
 

--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -800,7 +800,7 @@
   description: |
     Your specialization in a particular type of energy or general protection causes you to be resistant to that type of energy.
   effect: |
-    Choose from the following energy types: fire, cold, lightning, acid, (or another at the GM’s discretion). When you are attacked with that energy type, you gain resistance to the attack as follows:
+    Choose from the following energy types: fire, cold, lightning, acid, (or another at the GM's discretion). When you are attacked with that energy type, you gain resistance to the attack as follows:
     <ul>
     <li><strong>Tier 1</strong> - Your defense scores are increased by 3 against the chosen energy type.</li>
     <li><strong>Tier 2</strong> - Your defense scores are increased by 6 against the chosen energy type.</li>
@@ -932,7 +932,7 @@
   cost:
   - 2
   description: |
-    Creatures that you’ve magically compelled become even stronger when fighting in your defense or under your command.
+    Creatures that you've magically compelled become even stronger when fighting in your defense or under your command.
   effect: |
     Creatures under the effects of your Charmed or Dominated bane gain advantage 1 on all attack rolls to defend or help you for each tier of this feat you possess.
 - !
@@ -1089,7 +1089,7 @@
       Attribute 8 = 10 miles<br />
       Attribute 9 = 100 miles<br /></li>
     <li>Negate two levels of disadvantage caused by multi-targeting (e.g., Target 2 creatures or a 10' square for free instead of disadvantage 2).</li>
-    <li>For your action roll, treat your attribute score as if it was one greater for purposes of determining attribute dice. Note that this doesn’t grant access to banes or boons you could not normally access. It only increases the dice used for the action roll.</li>
+    <li>For your action roll, treat your attribute score as if it was one greater for purposes of determining attribute dice. Note that this doesn't grant access to banes or boons you could not normally access. It only increases the dice used for the action roll.</li>
     </ul>
 
     <strong>Tier 2</strong> - You gain the following abilities:
@@ -1297,7 +1297,7 @@
   description: |
     You have knowledge of a particular area of study which far surpasses your general intelligence.
   effect: |
-    When you purchase this feat, choose a sphere of knowledge from the list below or, with the GM’s approval, create a new one. <br />
+    When you purchase this feat, choose a sphere of knowledge from the list below or, with the GM's approval, create a new one. <br />
     Example spheres of knowledge include alchemy, arcane, supernatural, engineering, geography, history, location (must specify), anatomy, medicine, explosives, computers, herbalism, and wilderness.<br />
     Your tier in this feat determines how knowledgeable you are within your chosen sphere.
     <ul>
@@ -1744,7 +1744,7 @@
   effect: |
     Choose one attribute. Any time you make a non-attack action roll with the chosen attribute, you gain advantage 1 on the roll per tier of this feat you possess for that attribute.
   special: |
-    You can take this feat multiple times. Each time, you can either apply it to a different attribute or increase the feat tier for an attribute you’ve already purchased.
+    You can take this feat multiple times. Each time, you can either apply it to a different attribute or increase the feat tier for an attribute you've already purchased.
 - !
   name: Superior Concentration (I - III)
   prerequisites:
@@ -1851,7 +1851,7 @@
   description: |
     Your charm is so potent that your victims may become permanently enthralled by you.
   effect: |
-    When you invoke the charmed bane, targets who do not make their resist roll within 24 hours of being afflicted become permanently affected by the bane. They do not receive any more resist rolls to shake themselves free of the effect. Other extraordinary effects like a Nullify bane can still end the effect (and other methods may work at the GM’s discretion).
+    When you invoke the charmed bane, targets who do not make their resist roll within 24 hours of being afflicted become permanently affected by the bane. They do not receive any more resist rolls to shake themselves free of the effect. Other extraordinary effects like a Nullify bane can still end the effect (and other methods may work at the GM's discretion).
 - !
   name: Untrackable
   prerequisites:


### PR DESCRIPTION
Replaced `’` (apostrophe) for `'` (typewriter apostrophe). See #312.