### PR TITLE
Proposed Change to Spending Legendary Points

### DIFF
--- a/core/src/02-actions-attributes/01-chapter-two.md
+++ b/core/src/02-actions-attributes/01-chapter-two.md
@@ -231,9 +231,7 @@ The GM may also feel free to establish other rules for awarding legend points. F
 
 A PC may spend a maximum number of legend points equal to their level plus one in order to enhance a single action roll.
 
-Before making an action roll, the PC declares how many legend points they are spending, and gains advantage 1 on the roll for each legend point spent.
-
-Alternatively, a PC may choose to spend legend points after they make an action roll and are dissatisfied with the result. Each legend point spent applies a retroactive advantage 1 to the roll, allowing the player to roll additional attribute dice and recalculate the roll completely as if it was made with the new advantage total.
+Before making an action roll, the PC declares how many legend points they are spending, and gains advantage 1 on the roll for each legend point spent. Additionally, for each legend point spent on the roll a +1 is added to the end result.
 
 ## Attributes and Action Rolls in Play
 


### PR DESCRIPTION
The ability to apply Legend Points after the result goes against the "every roll matters" mantra to me and seems a bit min-maxy. With the previous rules, you would never want to apply the points prior to the roll as you could potentially waste them if you had a high initial roll.  Forcing the PC to commit to spending points  prior to the roll in an attempt to ensure a more legendary outcome makes the decision of spending the points more important.