### PR TITLE
Remove empty tier2 of Longshot feat

### DIFF
--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -1612,7 +1612,6 @@
         Attribute:
         - Agility: 5
         - Any Extraordinary: 5
-    tier2:
   tags:
   - Combat
   cost:


### PR DESCRIPTION
Nothing in the description of Longshot describes a second tier. Remove it.