### PR TITLE
Point to new Open Legend community site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@ Please note that Github is a place for specific, actionable feedback that focus 
 
 In order to reduce the chance of your issue being closed, follow these guidelines:
 
-* Don't ask rules questions, the [Open Legend community site](https://openlegend.mightybell.com) serves that purpose
-* Don't critique an existing rule without a proposed solution, discuss first on the [Open Legend community site](https://openlegend.mightybell.com)
+* Don't ask rules questions, the [Open Legend community site](http://community.openlegendrpg.com/) serves that purpose
+* Don't critique an existing rule without a proposed solution, discuss first on the [Open Legend community site](http://community.openlegendrpg.com/)
 * Try to stay on topic and take side conversations to a separate channel


### PR DESCRIPTION
The OL community site is now http://community.openlegendrpg.com/ rather than on MightyBell.