### PR TITLE
Move "Disrupting Attack" to be an alternate option under "Extraordinary success"

### DIFF
--- a/core/src/07-combat/01-chapter-seven.md
+++ b/core/src/07-combat/01-chapter-seven.md
@@ -111,7 +111,7 @@ These steps are explained in more detail below.
 | |
 | - |
 | **Attack Roll Total** - **Target Defense** = **Damage Dealt** *(minimum of 3 on success)* |
-| *(**Exceptional Success** - trigger a bane or cancel a boon if total is 10 or more over defense)* |
+| *(**Exceptional Success** - trigger a bane or disrupt concentration if total is 10 or more over defense)* |
 
 <br><br>
 
@@ -196,7 +196,7 @@ Make an action roll using the attribute determined in step 1. You deal damage eq
 
 If your attack roll exceeds the target's defense by 10 or more, you may apply one bane of a power level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target.
 
-As an alternative, you may choose to cancel a single boon of your choice affecting any of the targets of your attack.
+As an alternative to triggering a bane, you may choose to disrupt the target's concentration. You cancel a single boon being sustained by the target of your attack. If your attack targeted multiple foes, then you may cancel one boon being sustained by each target.
 
 <br><br>
 

--- a/core/src/07-combat/01-chapter-seven.md
+++ b/core/src/07-combat/01-chapter-seven.md
@@ -111,7 +111,7 @@ These steps are explained in more detail below.
 | |
 | - |
 | **Attack Roll Total** - **Target Defense** = **Damage Dealt** *(minimum of 3 on success)* |
-| *(**Exceptional Success** - trigger a bane if total is 10 or more over defense)* |
+| *(**Exceptional Success** - trigger a bane or cancel a boon if total is 10 or more over defense)* |
 
 <br><br>
 
@@ -195,6 +195,8 @@ Make an action roll using the attribute determined in step 1. You deal damage eq
 ###### Exceptional Success
 
 If your attack roll exceeds the target's defense by 10 or more, you may apply one bane of a power level less than or equal to the attribute you used for the attack. In order to apply a bane, your attack roll must equal or exceed the appropriate defense for that bane. If your attack targeted multiple foes, you may apply the bane to each qualifying target.
+
+As an alternative, you may choose to cancel a single boon of your choice affecting any of the targets of your attack.
 
 <br><br>
 
@@ -384,13 +386,8 @@ Many boons have a default duration of *sustain persists*, which means that every
 
 Using a focus action involves spending all of your energy and attention on one task. If you choose to forgo your major, move, and minor actions for a round, you may instead take a focus action. Choose one of the following types of focus action:
 
-- Disrupting Attack
 - Superior Action
 - Charge
-
-#### Disrupting Attack
-
-Make a damaging attack using the normal attack rules. If your roll exceeds the target's defense by 10 or more, then any boons being sustained by your target immediately end.
 
 #### Superior Action
 


### PR DESCRIPTION
So, here's the thing:

Disrupting Strike technically says "uses normal damaging attack rules", which means that if we don't specify otherwise, it **BOTH** triggers a bane and **ALSO** cancels a boon. I propose we streamline and make both part of _Extraordinary Success_.

Honestly, after seeing what people can do at high levels after layering a number of boons on top of each other, I actually think this will be a HUGE help in terms of balance, it means that you don't have to risk wasting an action to "Shoot the flying wizard out of the sky" or "Force the Ghost to manifest, canceling Insubstantial".

