### PR TITLE
Wrong Ferocious Minions prerequisites (CRITICAL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The game rules content of this repository are released under a special open-sour
 
 Click [Here](https://github.com/openlegend/core-rules/commits/master) to see changes in more detail.
 
+#### 2017 / 10 / 06
+-   `Ferocious Minions` incorrectly stated `Logic` as a prerequisite attribute. However, that was wrong. It should have said `Alteration` and `Energy`. It is now corrected.
+
 #### 2017 / 08 / 30
 -   Now while in `Shapeshift` you acquire only the Agility, Fortitude, Might, and Perception attributes of the new form.
 

--- a/feats/feats.yml
+++ b/feats/feats.yml
@@ -850,24 +850,27 @@
     tier1:
       any:
         Attribute:
+        - Alteration: 4
         - Creation: 4
         - Entropy: 4
+        - Energy: 4
         - Influence: 4
-        - Logic: 4
     tier2:
       any:
         Attribute:
+        - Alteration: 5
         - Creation: 5
         - Entropy: 5
+        - Energy: 5
         - Influence: 5
-        - Logic: 5
     tier3:
       any:
         Attribute:
+        - Alteration: 7
         - Creation: 7
         - Entropy: 7
+        - Energy: 7
         - Influence: 7
-        - Logic: 7
   tags:
   - Extraordinary
   - Influence


### PR DESCRIPTION
@brianfeister `Ferocious Minions` prerequisites are wrong on the site, because I confused `Animation` with `Summon Creature` (somehow) while editing. Now they are correct. I also bumped the changelog to reflect this change.