### PR TITLE
Fix Feats link in Chapter 4, Fixes #488

### DIFF
--- a/core/src/04-feats/01-chapter-four.md
+++ b/core/src/04-feats/01-chapter-four.md
@@ -8,7 +8,7 @@ During your adventurers, the GM will award you Experience Points (or XP) for acc
 
 ## Reading a Feat Description
 
-The full listing of feats is available in a searchable list [here](http://www.openlegendrpg.com/feats).
+The full listing of feats is available in a searchable list [here](http://openlegendrpg.com/feats).
 
 Each feat description includes the following elements.
 


### PR DESCRIPTION
The link to feats in Chapter 4 points to
**www**.openlegend.rpg.com/feats which in turn redirects to the home
page rather than to the Feats list